### PR TITLE
[OP-1574] Support marking loaded terminology/mapset/subset as "complete"

### DIFF
--- a/src/main/java/com/wci/termhub/algo/TreePositionAlgorithm.java
+++ b/src/main/java/com/wci/termhub/algo/TreePositionAlgorithm.java
@@ -123,7 +123,7 @@ public class TreePositionAlgorithm extends AbstractTerminologyAlgorithm {
     searchService.createIndex(ConceptTreePosition.class);
 
     final Terminology term = TerminologyUtility.getTerminology(searchService, getTerminology(),
-        getPublisher(), getVersion());
+        getPublisher(), getVersion(), false);
     if (term == null) {
       throw new Exception("Unable to find terminology = " + getTerminology() + ", publisher = "
           + getPublisher() + ", version = " + getVersion());

--- a/src/main/java/com/wci/termhub/fhir/util/FhirUtility.java
+++ b/src/main/java/com/wci/termhub/fhir/util/FhirUtility.java
@@ -825,4 +825,14 @@ public final class FhirUtility {
       return code;
     }
   }
+
+  /**
+   * Clear caches. Used only for testing.
+   */
+  public static void clearCaches() {
+    terminologyCache = new TimerCache<>(1000, 10000);
+    mapsetCache = new TimerCache<>(1000, 10000);
+    codeSystemUriCache = new TimerCache<>(1000, 10000);
+    displayMap = new HashMap<>();
+  }
 }

--- a/src/main/java/com/wci/termhub/lucene/LuceneDataAccess.java
+++ b/src/main/java/com/wci/termhub/lucene/LuceneDataAccess.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import com.wci.termhub.model.HasAttributes;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.TokenStream;
@@ -584,6 +585,10 @@ public class LuceneDataAccess {
     if (sp.getAscending() == null) {
       sp.setAscending(true);
     }
+
+    if (sp.getFilterUnloaded() == null) {
+      sp.setFilterUnloaded(true);
+    }
     try {
       final Query query = sp.getLuceneQuery() != null ? sp.getLuceneQuery()
           : LuceneQueryBuilder.parse(sp.getQuery(), clazz);
@@ -654,6 +659,18 @@ public class LuceneDataAccess {
       final T obj = mapper.readValue(jsonEntityString, clazz);
       if (LOGGER.isTraceEnabled()) {
         LOGGER.trace("search result: {}", obj);
+      }
+      if (searchParameters.getFilterUnloaded() == null || searchParameters.getFilterUnloaded()) {
+        // Any partially loaded objects are skipped
+        if (obj instanceof HasAttributes) {
+          Map<String, String> attributes = ((HasAttributes) obj).getAttributes();
+          if (attributes != null) {
+            String loaded = attributes.get("loaded");
+            if (loaded != null && loaded.equals("false")) {
+              continue;
+            }
+          }
+        }
       }
       results.getItems().add(obj);
     }
@@ -935,6 +952,9 @@ public class LuceneDataAccess {
       synchronized (READER_MAP) {
         if (!READER_MAP.containsKey(canonicalClassName)) {
           synchronized (READER_MAP) {
+            if(LOGGER.isTraceEnabled()){
+              LOGGER.trace("Creating new IndexReader for class: {}", canonicalClassName);
+            }
             final File indexDir = getIndexDirectory(clazz);
             final FSDirectory fsDirectory = FSDirectory.open(indexDir.toPath());
             reader = DirectoryReader.open(fsDirectory);

--- a/src/main/java/com/wci/termhub/model/SearchParameters.java
+++ b/src/main/java/com/wci/termhub/model/SearchParameters.java
@@ -79,6 +79,7 @@ public class SearchParameters extends BaseModel {
   /** The leaf. */
   private Boolean leaf;
 
+  private Boolean filterUnloaded;
   /**
    * Instantiates an empty {@link SearchParameters}.
    */
@@ -478,6 +479,24 @@ public class SearchParameters extends BaseModel {
   }
 
   /**
+   * Gets the include unloaded.
+   *
+   * @return the include unloaded
+   */
+  @Schema(description = "Include unloaded concepts in search results")
+  public Boolean getFilterUnloaded() {
+    return filterUnloaded;
+  }
+  /**
+   * Sets the include unloaded.
+   *
+   * @param filterUnloaded the new include unloaded
+   */
+  public void setFilterUnloaded(final Boolean filterUnloaded) {
+    this.filterUnloaded = filterUnloaded;
+  }
+
+  /**
    * Hash code.
    *
    * @return the int
@@ -486,7 +505,7 @@ public class SearchParameters extends BaseModel {
   @Override
   public int hashCode() {
     return Objects.hash(active, ascending, expression, field, filters, index, leaf, limit, offset,
-        query, sort, terminology, luceneQuery);
+        query, sort, terminology, luceneQuery, filterUnloaded);
   }
 
   /**
@@ -511,7 +530,7 @@ public class SearchParameters extends BaseModel {
         && Objects.equals(leaf, other.leaf) && Objects.equals(limit, other.limit)
         && Objects.equals(offset, other.offset) && Objects.equals(query, other.query)
         && Objects.equals(sort, other.sort) && Objects.equals(terminology, other.terminology)
-        && Objects.equals(luceneQuery, other.luceneQuery);
+        && Objects.equals(luceneQuery, other.luceneQuery) && Objects.equals(filterUnloaded, other.filterUnloaded);
   }
 
 }

--- a/src/main/java/com/wci/termhub/service/EntityRepositoryService.java
+++ b/src/main/java/com/wci/termhub/service/EntityRepositoryService.java
@@ -103,6 +103,18 @@ public interface EntityRepositoryService {
   public <T extends HasId> T get(final String id, final Class<T> clazz) throws Exception;
 
   /**
+   * Find by id.
+   *
+   * @param <T> the generic type
+   * @param id the id
+   * @param clazz the clazz
+   * @param filterUnloaded the filter unloaded entities
+   * @return the optional
+   * @throws Exception the exception
+   */
+  public <T extends HasId> T get(final String id, final Class<T> clazz, boolean filterUnloaded) throws Exception;
+
+  /**
    * Find ids.
    *
    * @param <T> the generic type

--- a/src/main/java/com/wci/termhub/service/impl/EntityServiceImpl.java
+++ b/src/main/java/com/wci/termhub/service/impl/EntityServiceImpl.java
@@ -149,9 +149,16 @@ public class EntityServiceImpl implements EntityRepositoryService {
   /* see superclass */
   @Override
   public <T extends HasId> T get(final String id, final Class<T> clazz) throws Exception {
+    return get(id, clazz, true);
+  }
+
+  /* see superclass */
+  @Override
+  public <T extends HasId> T get(final String id, final Class<T> clazz, boolean filterUnloaded) throws Exception {
 
     checkIfEntityHasDocumentAnnotation(clazz);
     final SearchParameters searchParameters = new SearchParameters();
+    searchParameters.setFilterUnloaded(filterUnloaded);
     searchParameters.setQuery("id:" + id);
     final ResultList<T> results = luceneDataAccess.find(clazz, searchParameters);
 

--- a/src/main/java/com/wci/termhub/util/CodeSystemLoaderUtil.java
+++ b/src/main/java/com/wci/termhub/util/CodeSystemLoaderUtil.java
@@ -337,7 +337,7 @@ public final class CodeSystemLoaderUtil {
       Application.logMemory();
 
       // Get the terminology again because the tree position computer would've changed it
-      terminology = service.get(terminology.getId(), Terminology.class);
+      terminology = service.get(terminology.getId(), Terminology.class, false);
       // Set loaded to true and save it again
       terminology.getAttributes().put("loaded", "true");
       service.update(Terminology.class, terminology.getId(), terminology);

--- a/src/main/java/com/wci/termhub/util/ConceptMapLoaderUtil.java
+++ b/src/main/java/com/wci/termhub/util/ConceptMapLoaderUtil.java
@@ -274,7 +274,7 @@ public final class ConceptMapLoaderUtil {
       LOGGER.info("  duration: {} ms", (System.currentTimeMillis() - startTime));
 
       // Get the mapset again because the tree position computer would've changed it
-      mapset = service.get(mapset.getId(), Mapset.class);
+      mapset = service.get(mapset.getId(), Mapset.class, false);
       // Set loaded to true and save it again
       mapset.getAttributes().put("loaded", "true");
       service.update(Mapset.class, mapset.getId(), mapset);

--- a/src/main/java/com/wci/termhub/util/TerminologyUtility.java
+++ b/src/main/java/com/wci/termhub/util/TerminologyUtility.java
@@ -149,17 +149,35 @@ public final class TerminologyUtility {
   public static Terminology getTerminology(final EntityRepositoryService searchService,
     final String terminology, final String publisher, final String version) throws Exception {
 
+    return getTerminology(searchService, terminology, publisher, version, true);
+  }
+
+  /**
+   * Gets the terminology.
+   *
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param publisher the publisher
+   * @param version the version
+   * @return the terminology
+   * @throws Exception the exception
+   */
+  public static Terminology getTerminology(final EntityRepositoryService searchService,
+                                           final String terminology, final String publisher, final String version, final boolean filterUnloaded) throws Exception {
+
     final String terminologyQuery = getTerminologyAbbrQuery(terminology, publisher, version);
+    SearchParameters searchParameters = new SearchParameters(terminologyQuery, 2, 0);
+    searchParameters.setFilterUnloaded(filterUnloaded);
     logger.info("  terminology query = " + terminologyQuery);
     final ResultList<Terminology> tlist =
-        searchService.find(new SearchParameters(terminologyQuery, 2, 0), Terminology.class);
+            searchService.find(searchParameters, Terminology.class);
 
     if (tlist.getItems().isEmpty()) {
       return null;
     }
     if (tlist.getItems().size() > 1) {
       throw new Exception(
-          "Too many terminology matches = " + terminology + ", " + publisher + ", " + version);
+              "Too many terminology matches = " + terminology + ", " + publisher + ", " + version);
     }
 
     return tlist.getItems().get(0);

--- a/src/main/java/com/wci/termhub/util/ValueSetLoaderUtil.java
+++ b/src/main/java/com/wci/termhub/util/ValueSetLoaderUtil.java
@@ -330,7 +330,7 @@ public final class ValueSetLoaderUtil {
       LOGGER.info("  duration: {} ms", (System.currentTimeMillis() - startTime));
 
       // Get the subset again because the tree position computer would've changed it
-      subset = service.get(subset.getId(), Subset.class);
+      subset = service.get(subset.getId(), Subset.class, false);
       // Set loaded to true and save it again
       subset.getAttributes().put("loaded", "true");
       service.update(Subset.class, subset.getId(), subset);
@@ -557,7 +557,7 @@ public final class ValueSetLoaderUtil {
       LOGGER.info("  duration: {} ms", (System.currentTimeMillis() - startTime));
 
       // Get the subset again because the tree position computer would've changed it
-      subset = service.get(subset.getId(), Subset.class);
+      subset = service.get(subset.getId(), Subset.class, false);
       // Set loaded to true and save it again
       subset.getAttributes().put("loaded", "true");
       service.update(Subset.class, subset.getId(), subset);

--- a/src/test/java/com/wci/termhub/fhir/r4/test/AbstractFhirR4ServerTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r4/test/AbstractFhirR4ServerTest.java
@@ -11,6 +11,10 @@ package com.wci.termhub.fhir.r4.test;
 
 import java.util.List;
 
+import com.wci.termhub.fhir.util.FhirUtility;
+import com.wci.termhub.model.Mapset;
+import com.wci.termhub.model.Subset;
+import com.wci.termhub.model.Terminology;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -101,4 +105,30 @@ public abstract class AbstractFhirR4ServerTest extends AbstractServerTest {
     setupOnce = true;
   }
 
+  protected void setTerminologyLoaded(Terminology terminology, boolean flag) throws Exception {
+    if(terminology == null) {
+      throw new Exception("Terminology cannot be null");
+    }
+    terminology.getAttributes().put("loaded", Boolean.toString(flag));
+    searchService.update(Terminology.class, terminology.getId(), terminology);
+    FhirUtility.clearCaches();
+  }
+
+  protected void setMapsetLoaded(Mapset mapset, boolean flag) throws Exception {
+    if(mapset == null) {
+      throw new Exception("Terminology cannot be null");
+    }
+    mapset.getAttributes().put("loaded", Boolean.toString(flag));
+    searchService.update(Mapset.class, mapset.getId(), mapset);
+    FhirUtility.clearCaches();
+  }
+
+  protected void setValuesetLoaded(Subset subset, boolean flag) throws Exception {
+    if(subset == null) {
+      throw new Exception("Terminology cannot be null");
+    }
+    subset.getAttributes().put("loaded", Boolean.toString(flag));
+    searchService.update(Subset.class, subset.getId(), subset);
+    FhirUtility.clearCaches();
+  }
 }

--- a/src/test/java/com/wci/termhub/fhir/r4/test/CodeSystemLoadR4UnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r4/test/CodeSystemLoadR4UnitTest.java
@@ -70,4 +70,6 @@ public class CodeSystemLoadR4UnitTest extends AbstractFhirR4ServerTest {
     }
   }
 
+
+
 }

--- a/src/test/java/com/wci/termhub/fhir/r4/test/FhirR4RestUnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r4/test/FhirR4RestUnitTest.java
@@ -9,11 +9,6 @@
  */
 package com.wci.termhub.fhir.r4.test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashSet;
@@ -23,7 +18,10 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 
+import com.wci.termhub.fhir.util.FhirUtility;
+import com.wci.termhub.util.ValueSetLoaderUtil;
 import org.hl7.fhir.r4.model.Bundle;
 import org.hl7.fhir.r4.model.Bundle.BundleEntryComponent;
 import org.hl7.fhir.r4.model.Bundle.BundleType;
@@ -40,6 +38,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -67,6 +66,8 @@ import com.wci.termhub.util.ThreadLocalMapper;
 
 import ca.uhn.fhir.context.FhirContext;
 import ca.uhn.fhir.parser.IParser;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Class tests for FhirR4Tests. Tests the functionality of the FHIR R4 endpoints, CodeSystem,
@@ -248,6 +249,47 @@ public class FhirR4RestUnitTest extends AbstractFhirR4ServerTest {
     // Verify all expected values were found
     assertTrue(expectedTitles.isEmpty(), "Missing code systems: " + expectedTitles);
     assertTrue(expectedPublishers.isEmpty(), "Missing publishers: " + expectedPublishers);
+  }
+
+  /**
+   * Test code system search.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  @Order(1)
+  @Disabled
+  public void testCodeSystemNotLoaded() throws Exception {
+    Terminology terminology = FhirUtility.getTerminology(searchService, "SNOMEDCT_US", "SANDBOX", "20240301");
+    try {
+      // Arrange
+      final String endpoint = LOCALHOST + port + FHIR_CODESYSTEM;
+      LOGGER.info("endpoint = {}", endpoint);
+
+      setTerminologyLoaded(terminology, false);
+
+      // Act
+      final String content = this.restTemplate.getForObject(endpoint, String.class);
+      final Bundle data = parser.parseResource(Bundle.class, content);
+      final List<Resource> codeSystems =
+              data.getEntry().stream().map(BundleEntryComponent::getResource).toList();
+
+      // Verify expected code systems
+      final Set<String> expectedTitles =
+              new HashSet<>(Set.of("ICD10CM", "LNC", "RXNORM", "SNOMEDCT"));
+      final Set<String> expectedPublishers = new HashSet<>(Set.of("SANDBOX"));
+
+      //assert that codesystems titles are all in expectedTitles in no particular order
+      assertEquals(expectedTitles, codeSystems.stream().map(r->((CodeSystem)r).getTitle()).collect(Collectors.toSet()));
+      assertEquals(expectedPublishers, codeSystems.stream().map(r->((CodeSystem)r).getPublisher()).collect(Collectors.toSet()));
+
+      // Assert code systems
+      assertFalse(codeSystems.isEmpty());
+      assertEquals(4, codeSystems.size());
+    }
+    finally {
+      setTerminologyLoaded(terminology, true);
+    }
   }
 
   /**
@@ -678,6 +720,39 @@ public class FhirR4RestUnitTest extends AbstractFhirR4ServerTest {
     // assertTrue(hasFullySpecifiedName, "Should have fully specified name
     // designation");
   }
+
+  @Test
+  @Disabled
+  public void testValuesetNotLoaded() throws Exception {
+    final String vsId =
+            ValueSetLoaderUtil.mapOriginalId("6729e634-e4ed-4adb-b8f7-7bb7861861bf");
+
+    Subset subset = searchService.get(vsId, Subset.class);
+    try {
+      // Arrange
+      final String endpoint = LOCALHOST + port + FHIR_VALUESET + "/" + vsId;
+      LOGGER.info("endpoint = {}", endpoint);
+
+      // Act
+      String content = this.restTemplate.getForObject(endpoint, String.class);
+      ValueSet valueSet = parser.parseResource(ValueSet.class, content);
+
+      // Assert
+      assertNotNull(valueSet);
+
+      setValuesetLoaded(subset, false);
+      content = this.restTemplate.getForObject(endpoint, String.class);
+      OperationOutcome outcome = parser.parseResource(OperationOutcome.class, content);
+
+      // Assert
+      assertEquals(1, outcome.getIssue().size());
+      assertTrue(outcome.getIssueFirstRep().getDiagnostics().contains("not found") );
+    }
+    finally {
+      setValuesetLoaded(subset, true);
+    }
+  }
+
 
   /**
    * Test ValueSet search.
@@ -1182,6 +1257,35 @@ public class FhirR4RestUnitTest extends AbstractFhirR4ServerTest {
     assertEquals(HttpStatus.NOT_FOUND, response2.getStatusCode());
     subsets = searchService.find(params, Subset.class);
     assertEquals(1, subsets.getTotal());
+  }
+
+  @Test
+  @Disabled
+  public void testConceptMapNotLoaded() throws Exception {
+    List<Mapset> mapsets = FhirUtility.lookupMapsets(searchService);
+    try {
+      // Arrange
+      final String endpoint = LOCALHOST + port + FHIR_CONCEPTMAP;
+      LOGGER.info("endpoint = {}", endpoint);
+
+      // Act
+      String content = this.restTemplate.getForObject(endpoint, String.class);
+      Bundle data = parser.parseResource(Bundle.class, content);
+      List<Resource> codeSystems =
+              data.getEntry().stream().map(BundleEntryComponent::getResource).toList();
+      assertEquals(1, codeSystems.size());
+
+      setMapsetLoaded(mapsets.get(0), false);
+      FhirUtility.clearCaches();
+      content = this.restTemplate.getForObject(endpoint, String.class);
+      data = parser.parseResource(Bundle.class, content);
+      codeSystems =
+              data.getEntry().stream().map(BundleEntryComponent::getResource).toList();
+      assertTrue(codeSystems.isEmpty());
+    }
+    finally {
+      setMapsetLoaded(mapsets.get(0), true);
+    }
   }
 
   /**


### PR DESCRIPTION
Second part of the PR which restricts reads from entities that are still being loaded.