### PR TITLE
OP-2441 questionnaire valueset

### DIFF
--- a/src/main/java/com/wci/termhub/fhir/r4/ValueSetProviderR4.java
+++ b/src/main/java/com/wci/termhub/fhir/r4/ValueSetProviderR4.java
@@ -171,7 +171,7 @@ public class ValueSetProviderR4 implements IResourceProvider {
       final Subset subset = idPart != null ? searchService.get(idPart, Subset.class) : null;
       if (subset != null) {
         final List<SubsetMember> members = findSubsetMembersForSubset(subset);
-        return FhirUtilityR4.toR4ValueSet(subset, members, false);
+        return FhirUtilityR4.toR4ValueSet(subset, members, false, searchService);
       }
       throw FhirUtilityR4.exception("Value set not found = " + (idPart == null ? "null" : idPart),
           IssueType.NOTFOUND, HttpServletResponse.SC_NOT_FOUND);
@@ -1342,7 +1342,7 @@ public class ValueSetProviderR4 implements IResourceProvider {
       // final List<SubsetMember> members =
       // searchService.findAll(memberParams, SubsetMember.class).getItems();
       final ValueSet set =
-          FhirUtilityR4.toR4ValueSet(subset, new ArrayList<SubsetMember>(0), metaFlag);
+          FhirUtilityR4.toR4ValueSet(subset, new ArrayList<SubsetMember>(0), metaFlag, searchService);
       // Apply the same filtering as above
       if ((id != null && !id.getValue().equals(set.getId()))
           || (url != null && !url.getValue().equals(set.getUrl()))) {

--- a/src/main/java/com/wci/termhub/fhir/r4/ValueSetProviderR4.java
+++ b/src/main/java/com/wci/termhub/fhir/r4/ValueSetProviderR4.java
@@ -156,7 +156,11 @@ public class ValueSetProviderR4 implements IResourceProvider {
                 loincValueSetHelper.buildLllgComposeStructure(items);
             logger.info("GET ValueSet/{}: returning compose only (no expansion), members={}",
                 idPart, items.size());
-            return FhirUtilityR4.toR4LllgValueSetWithComposeOnly(loinc, idPart, composeStructure);
+            final Concept lllgConcept =
+                loincValueSetHelper.findLllgConcept(searchService, loinc, idPart);
+            final String valueSetId = lllgConcept != null ? lllgConcept.getId() : null;
+            return FhirUtilityR4.toR4LllgValueSetWithComposeOnly(loinc, idPart, valueSetId,
+                composeStructure);
           }
           logger.info("GET ValueSet/{}: LL/LG path skipped (LOINC terminology not found)", idPart);
         }
@@ -166,6 +170,31 @@ public class ValueSetProviderR4 implements IResourceProvider {
           .filter(s -> s.getId().equals(idPart)).findFirst().orElse(null);
       if (vs != null && vs.getId().endsWith("_entire")) {
         return vs;
+      }
+      // 2.5 LOINC LL/LG by Concept UUID
+      if (idPart != null && loincValueSetHelper.isEnabled()) {
+        final Concept concept = searchService.get(idPart, Concept.class);
+        if (concept != null && concept.getCode() != null
+            && loincValueSetHelper.isLllgId(concept.getCode())) {
+          Terminology loincTerm = TerminologyUtility.getTerminology(searchService,
+              concept.getTerminology(), concept.getPublisher(), concept.getVersion());
+          if (loincTerm == null) {
+            loincTerm = loincValueSetHelper.findLoincTerminology(searchService);
+          }
+          if (loincTerm != null) {
+            final int memberLimit = 10_000;
+            final ResultList<Concept> list = loincValueSetHelper.findLllgMembers(searchService,
+                loincTerm, concept.getCode(), 0, memberLimit);
+            final List<Concept> items = new ArrayList<>(list.getItems());
+            loincValueSetHelper.sortDirectLllgMembers(concept.getCode(), items);
+            final LoincValueSetHelper.LllgComposeStructure composeStructure =
+                loincValueSetHelper.buildLllgComposeStructure(items);
+            logger.info("GET ValueSet/{}: returning LL/LG compose by concept UUID, members={}",
+                idPart, items.size());
+            return FhirUtilityR4.toR4LllgValueSetWithComposeOnly(loincTerm, concept.getCode(),
+                concept.getId(), composeStructure);
+          }
+        }
       }
       // 3. Check explicit subsets
       final Subset subset = idPart != null ? searchService.get(idPart, Subset.class) : null;
@@ -1422,9 +1451,14 @@ public class ValueSetProviderR4 implements IResourceProvider {
             loincForLllg = loinc;
           }
           if (loincForLllg != null) {
-            final ValueSet lllgVs = FhirUtilityR4.toR4LllgValueSet(loincForLllg, lllgId, metaFlag);
-            final boolean idUrlMatch = (id == null || id.getValue().equals(lllgVs.getId()))
-                && (url == null || url.getValue().equals(lllgVs.getUrl()));
+            final Concept lllgConcept =
+                loincValueSetHelper.findLllgConcept(searchService, loincForLllg, lllgId);
+            final String valueSetId = lllgConcept != null ? lllgConcept.getId() : null;
+            final ValueSet lllgVs =
+                FhirUtilityR4.toR4LllgValueSet(loincForLllg, lllgId, valueSetId, metaFlag);
+            final boolean idUrlMatch =
+                (id == null || FhirUtilityR4.matchesLllgValueSetId(id.getValue(), lllgVs))
+                    && (url == null || url.getValue().equals(lllgVs.getUrl()));
             final boolean dateMatch =
                 date == null || FhirUtility.compareDate(date, lllgVs.getDate());
             final boolean versionMatch =
@@ -1457,8 +1491,9 @@ public class ValueSetProviderR4 implements IResourceProvider {
               }
               final ValueSet lgVs =
                   FhirUtilityR4.toR4LllgValueSetFromConcept(loincTerm, concept, metaFlag);
-              final boolean idUrlMatch = (id == null || id.getValue().equals(lgVs.getId()))
-                  && (url == null || url.getValue().equals(lgVs.getUrl()));
+              final boolean idUrlMatch =
+                  (id == null || FhirUtilityR4.matchesLllgValueSetId(id.getValue(), lgVs))
+                      && (url == null || url.getValue().equals(lgVs.getUrl()));
               final boolean dateMatch =
                   date == null || FhirUtility.compareDate(date, lgVs.getDate());
               final boolean versionMatch =

--- a/src/main/java/com/wci/termhub/fhir/r5/QuestionnaireProviderR5.java
+++ b/src/main/java/com/wci/termhub/fhir/r5/QuestionnaireProviderR5.java
@@ -7,7 +7,7 @@
  * and are protected by trade secret or copyright law.  Dissemination of this information
  * or reproduction of this material is strictly forbidden.
  */
-package com.wci.termhub.fhir.r4;
+package com.wci.termhub.fhir.r5;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -15,19 +15,19 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hl7.fhir.r4.model.Bundle;
-import org.hl7.fhir.r4.model.IdType;
-import org.hl7.fhir.r4.model.OperationOutcome;
-import org.hl7.fhir.r4.model.OperationOutcome.IssueType;
-import org.hl7.fhir.r4.model.Questionnaire;
-import org.hl7.fhir.r4.model.StringType;
-import org.hl7.fhir.r4.model.UriType;
+import org.hl7.fhir.r5.model.Bundle;
+import org.hl7.fhir.r5.model.IdType;
+import org.hl7.fhir.r5.model.OperationOutcome;
+import org.hl7.fhir.r5.model.OperationOutcome.IssueType;
+import org.hl7.fhir.r5.model.Questionnaire;
+import org.hl7.fhir.r5.model.StringType;
+import org.hl7.fhir.r5.model.UriType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import com.wci.termhub.fhir.rest.r4.FhirUtilityR4;
+import com.wci.termhub.fhir.rest.r5.FhirUtilityR5;
 import com.wci.termhub.fhir.util.FHIRServerResponseException;
 import com.wci.termhub.fhir.util.FhirUtility;
 import com.wci.termhub.fhir.util.LoincConstants;
@@ -57,13 +57,13 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 /**
- * QuestionnaireProviderR4. Prepared for a POC. Not fully tested or implemented.
+ * QuestionnaireProviderR5. Prepared for a POC. Not fully tested or implemented.
  */
 @Component
-public class QuestionnaireProviderR4 implements IResourceProvider {
+public class QuestionnaireProviderR5 implements IResourceProvider {
 
   /** The logger. */
-  private static Logger logger = LoggerFactory.getLogger(QuestionnaireProviderR4.class);
+  private static Logger logger = LoggerFactory.getLogger(QuestionnaireProviderR5.class);
 
   /** The search service. */
   @Autowired
@@ -99,7 +99,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
 
       // Validate input parameters
       if (id == null || id.getIdPart() == null || id.getIdPart().trim().isEmpty()) {
-        throw FhirUtilityR4.exception("Questionnaire ID is required", IssueType.INVALID,
+        throw FhirUtilityR5.exception("Questionnaire ID is required", IssueType.INVALID,
             HttpServletResponse.SC_BAD_REQUEST);
       }
 
@@ -111,7 +111,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       final Concept concept =
           TerminologyUtility.getConcept(searchService, latestTerminologyVersion, conceptCode);
       if (concept == null) {
-        throw FhirUtilityR4.exception(
+        throw FhirUtilityR5.exception(
             "Questionnaire not found = " + (id == null ? "null" : id.getIdPart()),
             IssueType.NOTFOUND, HttpServletResponse.SC_NOT_FOUND);
       }
@@ -119,16 +119,16 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       // Verify the code represents a questionnaire (has PanelType:Panel
       // attribute)
       if (!isQuestionnaireConcept(concept)) {
-        throw FhirUtilityR4.exception("Concept " + conceptCode + " is not a questionnaire",
+        throw FhirUtilityR5.exception("Concept " + conceptCode + " is not a questionnaire",
             IssueType.NOTFOUND, HttpServletResponse.SC_NOT_FOUND);
       }
 
       // Convert found concept to Questionnaire resource and return
       final Questionnaire questionnaire =
-          FhirUtilityR4.toR4Questionnaire(concept, searchService, latestTerminologyVersion);
+          FhirUtilityR5.toR5Questionnaire(concept, searchService, latestTerminologyVersion);
 
       // Populate with questions and answers
-      FhirUtilityR4.populateQuestionnaire(questionnaire, searchService, latestTerminologyVersion);
+      FhirUtilityR5.populateQuestionnaire(questionnaire, searchService, latestTerminologyVersion);
 
       return questionnaire;
 
@@ -136,7 +136,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       throw e;
     } catch (final Exception e) {
       logger.error("Unexpected FHIR error", e);
-      throw FhirUtilityR4.exception("Failed to get questionnaire",
+      throw FhirUtilityR5.exception("Failed to get questionnaire",
           OperationOutcome.IssueType.EXCEPTION, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -201,7 +201,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       // Validate and process search parameters
       validateSearchParameters(count, offset);
 
-      FhirUtilityR4.notSupportedSearchParams(request);
+      FhirUtilityR5.notSupportedSearchParams(request);
 
       // Get possible questionnaires with enhanced search capabilities
       final List<Questionnaire> allQuestionnaires = findPossibleQuestionnaires(true, id, code, date,
@@ -215,13 +215,13 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       // Create and return bundle with proper paging support
       // Note: makeBundle will handle the paging by only including the requested
       // page
-      return FhirUtilityR4.makeBundle(request, allQuestionnaires, count, offset);
+      return FhirUtilityR5.makeBundle(request, allQuestionnaires, count, offset);
 
     } catch (final FHIRServerResponseException e) {
       throw e;
     } catch (final Exception e) {
       logger.error("Unexpected FHIR error", e);
-      throw FhirUtilityR4.exception("Failed to find questionnaires",
+      throw FhirUtilityR5.exception("Failed to find questionnaires",
           OperationOutcome.IssueType.EXCEPTION, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
     }
   }
@@ -240,11 +240,11 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
     if (count != null) {
       final int countValue = count.getValue().intValue();
       if (countValue < 0) {
-        throw FhirUtilityR4.exception("_count parameter must be non-negative", IssueType.INVALID,
+        throw FhirUtilityR5.exception("_count parameter must be non-negative", IssueType.INVALID,
             HttpServletResponse.SC_BAD_REQUEST);
       }
       if (countValue > 2000) {
-        throw FhirUtilityR4.exception("_count parameter cannot exceed 2000", IssueType.INVALID,
+        throw FhirUtilityR5.exception("_count parameter cannot exceed 2000", IssueType.INVALID,
             HttpServletResponse.SC_BAD_REQUEST);
       }
     }
@@ -253,7 +253,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
     if (offset != null) {
       final int offsetValue = offset.getValue().intValue();
       if (offsetValue < 0) {
-        throw FhirUtilityR4.exception("_offset parameter must be non-negative", IssueType.INVALID,
+        throw FhirUtilityR5.exception("_offset parameter must be non-negative", IssueType.INVALID,
             HttpServletResponse.SC_BAD_REQUEST);
       }
     }
@@ -352,7 +352,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
   private Terminology requireLoincTerminology() throws FHIRServerResponseException {
     final Terminology terminology = loincValueSetHelper.findLoincTerminology(searchService);
     if (terminology == null) {
-      throw FhirUtilityR4.exception("LOINC terminology not found", IssueType.NOTFOUND,
+      throw FhirUtilityR5.exception("LOINC terminology not found", IssueType.NOTFOUND,
           HttpServletResponse.SC_NOT_FOUND);
     }
     return terminology;
@@ -416,9 +416,9 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
             TerminologyUtility.getConcept(searchService, loincTerminology, codeValue);
 
         if (concept != null && isQuestionnaireConcept(concept)) {
-          final Questionnaire questionnaire = FhirUtilityR4.toR4Questionnaire(concept, searchService,
+          final Questionnaire questionnaire = FhirUtilityR5.toR5Questionnaire(concept, searchService,
               loincTerminology);
-          FhirUtilityR4.populateQuestionnaire(questionnaire, searchService, loincTerminology);
+          FhirUtilityR5.populateQuestionnaire(questionnaire, searchService, loincTerminology);
           list.add(questionnaire);
         }
       } catch (final Exception e) {
@@ -441,7 +441,7 @@ public class QuestionnaireProviderR4 implements IResourceProvider {
       }
 
       final Questionnaire questionnaire =
-          FhirUtilityR4.toR4Questionnaire(concept, searchService, loincTerminology);
+          FhirUtilityR5.toR5Questionnaire(concept, searchService, loincTerminology);
 
       // Apply filtering based on search criteria
       if (!matchesSearchCriteria(questionnaire, id, code, date, description, identifier, name,

--- a/src/main/java/com/wci/termhub/fhir/r5/ValueSetProviderR5.java
+++ b/src/main/java/com/wci/termhub/fhir/r5/ValueSetProviderR5.java
@@ -171,7 +171,7 @@ public class ValueSetProviderR5 implements IResourceProvider {
       final Subset subset = idPart != null ? searchService.get(idPart, Subset.class) : null;
       if (subset != null) {
         final List<SubsetMember> members = findSubsetMembersForSubset(subset);
-        return FhirUtilityR5.toR5ValueSet(subset, members, false);
+        return FhirUtilityR5.toR5ValueSet(subset, members, false, searchService);
       }
       throw FhirUtilityR5.exception("Value set not found = " + (idPart == null ? "null" : idPart),
           IssueType.NOTFOUND, HttpServletResponse.SC_NOT_FOUND);
@@ -1319,7 +1319,7 @@ public class ValueSetProviderR5 implements IResourceProvider {
       // final List<SubsetMember> members =
       // searchService.findAll(memberParams, SubsetMember.class).getItems();
       final ValueSet set =
-          FhirUtilityR5.toR5ValueSet(subset, new ArrayList<SubsetMember>(0), metaFlag);
+          FhirUtilityR5.toR5ValueSet(subset, new ArrayList<SubsetMember>(0), metaFlag, searchService);
       // Apply the same filtering as above
       if ((id != null && !id.getValue().equals(set.getId()))
           || (url != null && !url.getValue().equals(set.getUrl()))) {

--- a/src/main/java/com/wci/termhub/fhir/r5/ValueSetProviderR5.java
+++ b/src/main/java/com/wci/termhub/fhir/r5/ValueSetProviderR5.java
@@ -156,7 +156,11 @@ public class ValueSetProviderR5 implements IResourceProvider {
                 loincValueSetHelper.buildLllgComposeStructure(items);
             logger.info("GET ValueSet/{}: returning compose only (no expansion), members={}",
                 idPart, items.size());
-            return FhirUtilityR5.toR5LllgValueSetWithComposeOnly(loinc, idPart, composeStructure);
+            final Concept lllgConcept =
+                loincValueSetHelper.findLllgConcept(searchService, loinc, idPart);
+            final String valueSetId = lllgConcept != null ? lllgConcept.getId() : null;
+            return FhirUtilityR5.toR5LllgValueSetWithComposeOnly(loinc, idPart, valueSetId,
+                composeStructure);
           }
           logger.debug("GET ValueSet/{}: LL/LG path skipped (LOINC terminology not found)", idPart);
         }
@@ -166,6 +170,31 @@ public class ValueSetProviderR5 implements IResourceProvider {
           .filter(s -> s.getId().equals(idPart)).findFirst().orElse(null);
       if (vs != null && vs.getId().endsWith("_entire")) {
         return vs;
+      }
+      // 2.5 LOINC LL/LG by Concept UUID
+      if (idPart != null && loincValueSetHelper.isEnabled()) {
+        final Concept concept = searchService.get(idPart, Concept.class);
+        if (concept != null && concept.getCode() != null
+            && loincValueSetHelper.isLllgId(concept.getCode())) {
+          Terminology loincTerm = TerminologyUtility.getTerminology(searchService,
+              concept.getTerminology(), concept.getPublisher(), concept.getVersion());
+          if (loincTerm == null) {
+            loincTerm = loincValueSetHelper.findLoincTerminology(searchService);
+          }
+          if (loincTerm != null) {
+            final int memberLimit = 10_000;
+            final ResultList<Concept> list = loincValueSetHelper.findLllgMembers(searchService,
+                loincTerm, concept.getCode(), 0, memberLimit);
+            final List<Concept> items = new ArrayList<>(list.getItems());
+            loincValueSetHelper.sortDirectLllgMembers(concept.getCode(), items);
+            final LoincValueSetHelper.LllgComposeStructure composeStructure =
+                loincValueSetHelper.buildLllgComposeStructure(items);
+            logger.info("GET ValueSet/{}: returning LL/LG compose by concept UUID, members={}",
+                idPart, items.size());
+            return FhirUtilityR5.toR5LllgValueSetWithComposeOnly(loincTerm, concept.getCode(),
+                concept.getId(), composeStructure);
+          }
+        }
       }
       // 3. Check explicit subsets
       final Subset subset = idPart != null ? searchService.get(idPart, Subset.class) : null;
@@ -1399,9 +1428,14 @@ public class ValueSetProviderR5 implements IResourceProvider {
             loincForLllg = loinc;
           }
           if (loincForLllg != null) {
-            final ValueSet lllgVs = FhirUtilityR5.toR5LllgValueSet(loincForLllg, lllgId, metaFlag);
-            final boolean idUrlMatch = (id == null || id.getValue().equals(lllgVs.getId()))
-                && (url == null || url.getValue().equals(lllgVs.getUrl()));
+            final Concept lllgConcept =
+                loincValueSetHelper.findLllgConcept(searchService, loincForLllg, lllgId);
+            final String valueSetId = lllgConcept != null ? lllgConcept.getId() : null;
+            final ValueSet lllgVs =
+                FhirUtilityR5.toR5LllgValueSet(loincForLllg, lllgId, valueSetId, metaFlag);
+            final boolean idUrlMatch =
+                (id == null || FhirUtilityR5.matchesLllgValueSetId(id.getValue(), lllgVs))
+                    && (url == null || url.getValue().equals(lllgVs.getUrl()));
             final boolean dateMatch =
                 date == null || FhirUtility.compareDate(date, lllgVs.getDate());
             final boolean versionMatch =
@@ -1434,8 +1468,9 @@ public class ValueSetProviderR5 implements IResourceProvider {
               }
               final ValueSet lgVs =
                   FhirUtilityR5.toR5LllgValueSetFromConcept(loincTerm, concept, metaFlag);
-              final boolean idUrlMatch = (id == null || id.getValue().equals(lgVs.getId()))
-                  && (url == null || url.getValue().equals(lgVs.getUrl()));
+              final boolean idUrlMatch =
+                  (id == null || FhirUtilityR5.matchesLllgValueSetId(id.getValue(), lgVs))
+                      && (url == null || url.getValue().equals(lgVs.getUrl()));
               final boolean dateMatch =
                   date == null || FhirUtility.compareDate(date, lgVs.getDate());
               final boolean versionMatch =

--- a/src/main/java/com/wci/termhub/fhir/rest/r4/FhirUtilityR4.java
+++ b/src/main/java/com/wci/termhub/fhir/rest/r4/FhirUtilityR4.java
@@ -1171,11 +1171,12 @@ public final class FhirUtilityR4 {
    * @param subset the Subset
    * @param members the SubsetMembers
    * @param metaFlag the meta flag
+   * @param searchService the search service (used to resolve copyright from source terminology)
    * @return the FHIR R4 ValueSet
    * @throws Exception the exception
    */
   public static ValueSet toR4ValueSet(final Subset subset, final List<SubsetMember> members,
-    final boolean metaFlag) throws Exception {
+    final boolean metaFlag, final EntityRepositoryService searchService) throws Exception {
 
     final ValueSet valueSet = new ValueSet();
     valueSet.setId(subset.getId());
@@ -1203,6 +1204,8 @@ public final class FhirUtilityR4 {
     }
     valueSet.setDescription(subset.getDescription());
     valueSet.setStatus(Enumerations.PublicationStatus.ACTIVE);
+
+    applyCopyrightFromTerminology(valueSet, subset, searchService);
 
     // Set experimental from attributes if present, else fallback
     final String experimentalStr = subset.getAttributes() != null
@@ -1253,6 +1256,34 @@ public final class FhirUtilityR4 {
     valueSet.getMeta().setLastUpdated(DateUtility.parseToUtcDate(subset.getCreated()));
 
     return valueSet;
+  }
+
+  /**
+   * Sets ValueSet copyright from source terminology when available, otherwise from subset
+   * attributes (preserved at import).
+   *
+   * @param valueSet the value set
+   * @param subset the subset
+   * @param searchService the search service
+   * @throws Exception the exception
+   */
+  private static void applyCopyrightFromTerminology(final ValueSet valueSet, final Subset subset,
+    final EntityRepositoryService searchService) throws Exception {
+
+    String copyright = null;
+    if (searchService != null && subset.getFromTerminology() != null) {
+      final Terminology terminology = TerminologyUtility.getTerminology(searchService,
+          subset.getFromTerminology(), subset.getFromPublisher(), subset.getFromVersion(), false);
+      if (terminology != null && terminology.getAttributes() != null) {
+        copyright = terminology.getAttributes().get("copyright");
+      }
+    }
+    if (copyright == null && subset.getAttributes() != null) {
+      copyright = subset.getAttributes().get("copyright");
+    }
+    if (copyright != null) {
+      valueSet.setCopyright(copyright);
+    }
   }
 
   /**

--- a/src/main/java/com/wci/termhub/fhir/rest/r4/FhirUtilityR4.java
+++ b/src/main/java/com/wci/termhub/fhir/rest/r4/FhirUtilityR4.java
@@ -14,6 +14,7 @@ import static java.lang.String.format;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -65,6 +66,7 @@ import com.wci.termhub.fhir.util.CodeSystemMetadataProperty;
 import com.wci.termhub.fhir.util.CodeSystemMetadataPropertyUtility;
 import com.wci.termhub.fhir.util.FHIRServerResponseException;
 import com.wci.termhub.fhir.util.FhirUtility;
+import com.wci.termhub.fhir.util.LoincConstants;
 import com.wci.termhub.model.Concept;
 import com.wci.termhub.model.ConceptPropertyValueCoding;
 import com.wci.termhub.model.ConceptRef;
@@ -625,7 +627,7 @@ public final class FhirUtilityR4 {
     }
 
     final boolean isLoinc =
-        codeSystem.getUrl() != null && codeSystem.getUrl().contains("loinc.org");
+        codeSystem.getUrl() != null && codeSystem.getUrl().contains(LoincConstants.LOINC_URI);
 
     final List<ConceptRef> distinctHierarchicalParents =
         FhirUtility.distinctHierarchicalParents(relationships);
@@ -1024,13 +1026,16 @@ public final class FhirUtilityR4 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id (e.g. LL1162-8, LG51018-6-2.78)
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param metaFlag when true, add fromTerminology/fromPublisher/fromVersion and loincLllgId tags
    * @return the value set
    */
   public static ValueSet toR4LllgValueSet(final Terminology terminology, final String lllgId,
-    final boolean metaFlag) {
+    final String valueSetId, final boolean metaFlag) {
     final ValueSet set = new ValueSet();
-    set.setId(lllgId);
+    if (valueSetId != null) {
+      set.setId(valueSetId);
+    }
     set.setUrl(terminology.getUri() + "?fhir_vs=" + lllgId);
     set.setVersion(terminology.getVersion());
     set.setPublisher(terminology.getPublisher());
@@ -1058,7 +1063,7 @@ public final class FhirUtilityR4 {
   /**
    * Builds a minimal R4 ValueSet for a LOINC LL/LG concept found during enumeration. Sets name and
    * title from the concept's name in addition to the fields set by
-   * {@link #toR4LllgValueSet(Terminology, String, boolean)}.
+   * {@link #toR4LllgValueSet(Terminology, String, String, boolean)}.
    *
    * @param terminology LOINC terminology
    * @param concept the LL or LG concept (code used as lllgId, name used as title/name)
@@ -1067,12 +1072,34 @@ public final class FhirUtilityR4 {
    */
   public static ValueSet toR4LllgValueSetFromConcept(final Terminology terminology,
     final Concept concept, final boolean metaFlag) {
-    final ValueSet set = toR4LllgValueSet(terminology, concept.getCode(), metaFlag);
+    final ValueSet set =
+        toR4LllgValueSet(terminology, concept.getCode(), concept.getId(), metaFlag);
     if (concept.getName() != null) {
       set.setName(concept.getName());
       set.setTitle(concept.getName());
     }
     return set;
+  }
+
+  /**
+   * Returns true when the id search parameter matches a ValueSet id or its loincLllgId meta tag.
+   *
+   * @param idValue the _id search value
+   * @param vs the value set
+   * @return true if matches
+   */
+  public static boolean matchesLllgValueSetId(final String idValue, final ValueSet vs) {
+    if (idValue == null || vs == null) {
+      return idValue == null;
+    }
+    if (idValue.equals(vs.getId())) {
+      return true;
+    }
+    if (vs.getMeta() != null) {
+      return vs.getMeta().getTag().stream()
+          .anyMatch(t -> META_LOINC_LLLG_ID.equals(t.getSystem()) && idValue.equals(t.getCode()));
+    }
+    return false;
   }
 
   /**
@@ -1115,12 +1142,13 @@ public final class FhirUtilityR4 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id (e.g. LL1162-8, LG51018-6-2.78)
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param composeStructure partitioned compose structure from direct members
    * @return the value set with compose.include set, no expansion
    */
   public static ValueSet toR4LllgValueSetWithComposeOnly(final Terminology terminology,
-    final String lllgId, final LllgComposeStructure composeStructure) {
-    final ValueSet set = toR4LllgValueSet(terminology, lllgId, false);
+    final String lllgId, final String valueSetId, final LllgComposeStructure composeStructure) {
+    final ValueSet set = toR4LllgValueSet(terminology, lllgId, valueSetId, false);
     setR4LllgCompose(set, terminology.getUri(), composeStructure);
     return set;
   }
@@ -1131,6 +1159,7 @@ public final class FhirUtilityR4 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id (e.g. LL1162-8, LG51018-6-2.78)
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param composeStructure partitioned compose from direct members
    * @param leafMembers paginated leaf concepts for expansion.contains
    * @param expansionTotal total leaf count before pagination
@@ -1139,10 +1168,10 @@ public final class FhirUtilityR4 {
    * @return the value set with compose.include and expansion.contains set
    */
   public static ValueSet toR4LllgValueSetWithMembers(final Terminology terminology,
-    final String lllgId, final LllgComposeStructure composeStructure,
+    final String lllgId, final String valueSetId, final LllgComposeStructure composeStructure,
     final List<Concept> leafMembers, final int expansionTotal, final int expansionOffset,
     final int expansionCount) {
-    final ValueSet set = toR4LllgValueSet(terminology, lllgId, false);
+    final ValueSet set = toR4LllgValueSet(terminology, lllgId, valueSetId, false);
     final String systemUri = terminology.getUri();
     setR4LllgCompose(set, systemUri, composeStructure);
     if (systemUri == null || leafMembers == null) {
@@ -1724,6 +1753,103 @@ public final class FhirUtilityR4 {
   }
 
   /**
+   * Parses terminology release date for resource meta (same rules as CodeSystem).
+   *
+   * @param terminology the terminology
+   * @return release date or null
+   */
+  private static Date resolveTerminologyReleaseDate(final Terminology terminology)
+    throws Exception {
+    if (terminology == null) {
+      return null;
+    }
+    final String releaseDate = terminology.getReleaseDate();
+    if (releaseDate == null || releaseDate.isEmpty()) {
+      return null;
+    }
+    if (releaseDate.contains("T")) {
+      return Date.from(Instant.parse(releaseDate));
+    }
+    return DateUtility.DATE_YYYY_MM_DD_DASH.parse(releaseDate);
+  }
+
+  /**
+   * Builds Questionnaire meta consistent with CodeSystem: versionId, lastUpdated, optional
+   * originalId tag.
+   *
+   * @param terminology the terminology (optional)
+   * @param concept the concept (optional)
+   * @return the meta
+   */
+  private static Meta buildQuestionnaireMeta(final Terminology terminology, final Concept concept)
+    throws Exception {
+    final Meta meta = new Meta();
+    meta.setVersionId("1");
+    Date lastUpdated = resolveTerminologyReleaseDate(terminology);
+    if (lastUpdated == null && terminology != null && terminology.getCreated() != null) {
+      lastUpdated = DateUtility.parseToUtcDate(terminology.getCreated());
+    }
+    if (lastUpdated == null && concept != null) {
+      if (concept.getModified() != null) {
+        lastUpdated = DateUtility.parseToUtcDate(concept.getModified());
+      } else if (concept.getCreated() != null) {
+        lastUpdated = DateUtility.parseToUtcDate(concept.getCreated());
+      }
+    }
+    if (lastUpdated != null) {
+      meta.setLastUpdated(lastUpdated);
+    }
+    if (concept != null && concept.getAttributes() != null
+        && concept.getAttributes().containsKey("originalId")) {
+      meta.addTag("originalId", concept.getAttributes().get("originalId"), null);
+    } else if (terminology != null && terminology.getAttributes() != null
+        && terminology.getAttributes().containsKey("originalId")) {
+      meta.addTag("originalId", terminology.getAttributes().get("originalId"), null);
+    }
+    return meta;
+  }
+
+  /**
+   * Resolves terminology copyright (same source as CodeSystem).
+   *
+   * @param terminology the terminology
+   * @param searchService the search service (optional, reloads full record by id)
+   * @return copyright text or null
+   * @throws Exception the exception
+   */
+  private static String resolveTerminologyCopyright(final Terminology terminology,
+    final EntityRepositoryService searchService) throws Exception {
+    if (terminology == null) {
+      return null;
+    }
+    Terminology source = terminology;
+    if (searchService != null && terminology.getId() != null) {
+      final Terminology full = searchService.get(terminology.getId(), Terminology.class);
+      if (full != null) {
+        source = full;
+      }
+    }
+    final String copyright = source.getAttributes().get("copyright");
+    return StringUtility.isEmpty(copyright) ? null : copyright;
+  }
+
+  /**
+   * Sets Questionnaire copyright from terminology attributes when available.
+   *
+   * @param questionnaire the questionnaire
+   * @param terminology the terminology
+   * @param searchService the search service (optional)
+   * @throws Exception the exception
+   */
+  private static void applyQuestionnaireCopyright(final Questionnaire questionnaire,
+    final Terminology terminology, final EntityRepositoryService searchService) throws Exception {
+    final String copyright = resolveTerminologyCopyright(terminology, searchService);
+    if (copyright != null) {
+      questionnaire.setCopyright(copyright);
+    }
+  }
+
+  /**
    * Converts a Terminology to a FHIR R4 Questionnaire.
    *
    * @param terminology the Terminology
@@ -1743,21 +1869,21 @@ public final class FhirUtilityR4 {
     questionnaire.setStatus(PublicationStatus.ACTIVE);
     questionnaire
         .setDescription("Questionnaire representing the entire contents of this code system");
-    questionnaire.setDate(DateUtility.parseToUtcDate(terminology.getReleaseDate()));
-    questionnaire.setPublisher(terminology.getPublisher());
-
-    // Meta: versionId for _history, lastUpdated from release date (UTC)
-    if (metaFlag) {
-      questionnaire
-          .setMeta(new Meta().addTag("fromTerminology", terminology.getAbbreviation(), null)
-              .addTag("fromPublisher", terminology.getPublisher(), null)
-              .addTag("fromVersion", terminology.getVersion(), null)
-              .addTag("includesUri", terminology.getUri(), null));
-    } else {
-      questionnaire.setMeta(new Meta());
+    final Date releaseAsDate = resolveTerminologyReleaseDate(terminology);
+    if (releaseAsDate != null) {
+      questionnaire.setDate(releaseAsDate);
     }
-    questionnaire.getMeta().setVersionId("1");
-    questionnaire.getMeta().setLastUpdated(DateUtility.parseToUtcDate(terminology.getCreated()));
+    questionnaire.setPublisher(terminology.getPublisher());
+    applyQuestionnaireCopyright(questionnaire, terminology, null);
+
+    final Meta meta = buildQuestionnaireMeta(terminology, null);
+    if (metaFlag) {
+      meta.addTag("fromTerminology", terminology.getAbbreviation(), null)
+          .addTag("fromPublisher", terminology.getPublisher(), null)
+          .addTag("fromVersion", terminology.getVersion(), null)
+          .addTag("includesUri", terminology.getUri(), null);
+    }
+    questionnaire.setMeta(meta);
 
     return questionnaire;
   }
@@ -1773,6 +1899,21 @@ public final class FhirUtilityR4 {
    */
   public static Questionnaire toR4Questionnaire(final Concept concept,
     final EntityRepositoryService searchService) throws Exception {
+    return toR4Questionnaire(concept, searchService, null);
+  }
+
+  /**
+   * Converts a LOINC Concept to a FHIR R4 Questionnaire. This is the primary method for creating
+   * questionnaires from LOINC concepts.
+   *
+   * @param concept the LOINC Concept
+   * @param searchService the search service
+   * @param terminology the LOINC terminology (for meta.lastUpdated)
+   * @return the FHIR R4 Questionnaire
+   * @throws Exception the exception
+   */
+  public static Questionnaire toR4Questionnaire(final Concept concept,
+    final EntityRepositoryService searchService, final Terminology terminology) throws Exception {
 
     final Questionnaire questionnaire = new Questionnaire();
 
@@ -1784,8 +1925,13 @@ public final class FhirUtilityR4 {
         concept.getPublisher(), concept.getVersion());
     questionnaire.setUrl(systemUri + "/q/" + concept.getCode());
 
-    questionnaire.setName(concept.getName());
-    questionnaire.setTitle(concept.getName());
+    final String shortCommonName = resolveLoincShortCommonName(concept);
+    final String title =
+        !StringUtility.isEmpty(shortCommonName) ? shortCommonName : concept.getName();
+    final String name = !StringUtility.isEmpty(shortCommonName) ? toQuestionnaireName(shortCommonName)
+        : concept.getName();
+    questionnaire.setName(name);
+    questionnaire.setTitle(title);
     questionnaire.setStatus(PublicationStatus.DRAFT);
 
     // Set description from definitions if available, or use name as fallback
@@ -1807,7 +1953,7 @@ public final class FhirUtilityR4 {
     final Coding coding = new Coding();
     coding.setSystem(systemUri);
     coding.setCode(concept.getCode());
-    coding.setDisplay(concept.getName());
+    coding.setDisplay(title);
     questionnaire.addCode(coding);
 
     // Add contact information using concept data
@@ -1819,13 +1965,14 @@ public final class FhirUtilityR4 {
     contact.addTelecom(telecom);
     questionnaire.addContact(contact);
 
-    // Get copyright from concept attributes if available, otherwise use generic
-    String copyright = null;
-    if (concept.getAttributes() != null
-        && concept.getAttributes().containsKey("EXTERNAL_COPYRIGHT_NOTICE")) {
-      copyright = concept.getAttributes().get("EXTERNAL_COPYRIGHT_NOTICE");
+    Terminology copyrightTerminology = terminology;
+    if (copyrightTerminology == null && searchService != null) {
+      copyrightTerminology = TerminologyUtility.getTerminology(searchService,
+          concept.getTerminology(), concept.getPublisher(), concept.getVersion());
     }
-    questionnaire.setCopyright(copyright);
+    applyQuestionnaireCopyright(questionnaire, copyrightTerminology, searchService);
+
+    questionnaire.setMeta(buildQuestionnaireMeta(terminology, concept));
 
     return questionnaire;
   }
@@ -1865,7 +2012,7 @@ public final class FhirUtilityR4 {
         return;
       }
 
-      // Find group concepts via has_member relationships
+      // Find panel members via has_member or hierarchical parent relationships
       final List<Questionnaire.QuestionnaireItemComponent> groupItems = findGroupConcepts(
           mainConcept, searchService, terminology, processedCodes, terminology.getVersion());
 
@@ -1881,8 +2028,308 @@ public final class FhirUtilityR4 {
     }
   }
 
+  /** LOINC scale type attribute keys on indexed concepts. */
+  private static final String ATTR_SCALE_TYP = "SCALE_TYP";
+
+  /** Alternate LOINC scale type attribute key. */
+  private static final String ATTR_LOINC_SCALE_TYP = "LOINC_SCALE_TYP";
+
+  /** Panel member sequence on relationships. */
+  private static final String ATTR_SEQ_NO = "SEQ_NO";
+
   /**
-   * Finds group concepts via has_member relationships from the main concept.
+   * Finds panel member relationships for a questionnaire/panel code. Prefers outbound
+   * {@code member} edges (full LOINC), then {@code has_member} (sandbox); falls back to
+   * inbound hierarchical {@code parent} edges (child {@code from} → panel {@code to}).
+   *
+   * @param panelCode the panel or questionnaire code
+   * @param searchService the search service
+   * @param terminology the LOINC terminology
+   * @return sorted member relationships (may be empty)
+   * @throws Exception the exception
+   */
+  private static List<ConceptRelationship> findPanelMemberRelationships(final String panelCode,
+    final EntityRepositoryService searchService, final Terminology terminology) throws Exception {
+
+    final String termQuery = TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), terminology.getVersion());
+
+    final String memberQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("from.code", panelCode),
+        StringUtility.escapeKeywordField("additionalType", LoincConstants.LOINC_REL_PANEL_MEMBER));
+    final List<ConceptRelationship> memberRels =
+        searchService.findAll(memberQuery, null, ConceptRelationship.class);
+    if (!memberRels.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, memberRels));
+    }
+
+    final String hasMemberQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("from.code", panelCode),
+        StringUtility.escapeKeywordField("additionalType", LoincConstants.LOINC_REL_HAS_MEMBER));
+    final List<ConceptRelationship> hasMemberRels =
+        searchService.findAll(hasMemberQuery, null, ConceptRelationship.class);
+    if (!hasMemberRels.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, hasMemberRels));
+    }
+
+    final String childQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("to.code", panelCode), "hierarchical:true", "active:true");
+    final List<ConceptRelationship> childRels =
+        searchService.findAll(childQuery, null, ConceptRelationship.class);
+
+    final List<ConceptRelationship> filtered = new ArrayList<>();
+    for (final ConceptRelationship rel : childRels) {
+      if (rel.getHierarchical() == null || !rel.getHierarchical()) {
+        continue;
+      }
+      final ConceptRef memberRef = rel.getFrom();
+      if (memberRef == null || memberRef.getCode() == null || panelCode.equals(memberRef.getCode())) {
+        continue;
+      }
+      filtered.add(rel);
+    }
+    if (!filtered.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, filtered));
+    }
+
+    final String parentClause =
+        "parents.code:" + StringUtility.escapeQuery(panelCode);
+    final String excludePanel = "-code:" + StringUtility.escapeQuery(panelCode);
+    final String conceptQuery =
+        StringUtility.composeQuery("AND", termQuery, parentClause, excludePanel);
+    final SearchParameters params = new SearchParameters(conceptQuery, 500, 0);
+    final ResultList<Concept> childConcepts = searchService.find(params, Concept.class);
+
+    final List<ConceptRelationship> fromParents = new ArrayList<>();
+    for (final Concept child : childConcepts.getItems()) {
+      if (child.getCode() == null || panelCode.equals(child.getCode())) {
+        continue;
+      }
+      final ConceptRelationship rel = new ConceptRelationship();
+      rel.setHierarchical(true);
+      rel.setAdditionalType("parent");
+      rel.setFrom(new ConceptRef(child.getCode(), child.getName()));
+      rel.setTo(new ConceptRef(panelCode, null));
+      fromParents.add(rel);
+    }
+    return sortMemberRelationships(filterPanelMemberRelationships(panelCode, fromParents));
+  }
+
+  /**
+   * Drops self-references and LOINC part (LP*) targets from panel member relationships.
+   *
+   * @param panelCode the panel code
+   * @param relationships the candidate relationships
+   * @return filtered relationships
+   */
+  private static List<ConceptRelationship> filterPanelMemberRelationships(final String panelCode,
+    final List<ConceptRelationship> relationships) {
+    if (relationships == null || relationships.isEmpty()) {
+      return List.of();
+    }
+    final List<ConceptRelationship> filtered = new ArrayList<>();
+    for (final ConceptRelationship rel : relationships) {
+      final ConceptRef memberRef = getMemberConceptRef(rel);
+      if (memberRef == null || memberRef.getCode() == null) {
+        continue;
+      }
+      final String memberCode = memberRef.getCode();
+      if (panelCode.equals(memberCode) || memberCode.startsWith("LP")) {
+        continue;
+      }
+      filtered.add(rel);
+    }
+    return filtered;
+  }
+
+  /**
+   * Returns the member concept reference for a panel membership relationship.
+   *
+   * @param rel the relationship
+   * @return the member concept ref, or null
+   */
+  private static ConceptRef getMemberConceptRef(final ConceptRelationship rel) {
+    if (rel == null) {
+      return null;
+    }
+    final String additionalType = rel.getAdditionalType();
+    if (LoincConstants.LOINC_REL_HAS_MEMBER.equals(additionalType)
+        || LoincConstants.LOINC_REL_PANEL_MEMBER.equals(additionalType)) {
+      return rel.getTo();
+    }
+    if (Boolean.TRUE.equals(rel.getHierarchical())) {
+      return rel.getFrom();
+    }
+    return rel.getTo();
+  }
+
+  /**
+   * Sorts panel member relationships by sequence metadata when present.
+   *
+   * @param relationships the relationships
+   * @return sorted list
+   */
+  private static List<ConceptRelationship> sortMemberRelationships(
+    final List<ConceptRelationship> relationships) {
+    if (relationships == null || relationships.size() <= 1) {
+      return relationships == null ? List.of() : relationships;
+    }
+    final List<ConceptRelationship> sorted = new ArrayList<>(relationships);
+    sorted.sort(Comparator.comparingInt(FhirUtilityR4::relationshipSequenceNumber)
+        .thenComparing(rel -> {
+          final ConceptRef memberRef = getMemberConceptRef(rel);
+          return memberRef == null || memberRef.getCode() == null ? "" : memberRef.getCode();
+        }));
+    return sorted;
+  }
+
+  /**
+   * Sequence number for a panel member relationship.
+   *
+   * @param rel the relationship
+   * @return sequence number or max value if unknown
+   */
+  private static int relationshipSequenceNumber(final ConceptRelationship rel) {
+    if (rel == null) {
+      return Integer.MAX_VALUE;
+    }
+    if (rel.getAttributes() != null) {
+      final String seq = rel.getAttributes().get(ATTR_SEQ_NO);
+      if (seq != null) {
+        try {
+          return Integer.parseInt(seq);
+        } catch (final NumberFormatException e) {
+          // fall through
+        }
+      }
+    }
+    if (rel.getGroup() != null) {
+      try {
+        return Integer.parseInt(rel.getGroup());
+      } catch (final NumberFormatException e) {
+        // fall through
+      }
+    }
+    final ConceptRef memberRef = getMemberConceptRef(rel);
+    if (memberRef != null && memberRef.getCode() != null) {
+      return Integer.MAX_VALUE - 1;
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  /**
+   * Resolves the LOINC short common name for a concept (panel or member).
+   *
+   * @param concept the concept
+   * @return short common name or null
+   */
+  private static String resolveLoincShortCommonName(final Concept concept) {
+    return resolveLoincDisplayName(concept, null);
+  }
+
+  /**
+   * Converts a LOINC short common name to a FHIR Questionnaire.name (non-alphanumeric → underscore).
+   *
+   * @param shortCommonName the short common name
+   * @return machine name
+   */
+  private static String toQuestionnaireName(final String shortCommonName) {
+    if (StringUtility.isEmpty(shortCommonName)) {
+      return shortCommonName;
+    }
+    return shortCommonName.replaceAll("[^a-zA-Z0-9]+", "_").replaceAll("^_+|_+$", "");
+  }
+
+  /**
+   * Resolves the LOINC short common name for questionnaire item display.
+   *
+   * @param concept the loaded member concept (optional)
+   * @param fallback the member concept ref from a relationship (optional)
+   * @return display text
+   */
+  private static String resolveLoincDisplayName(final Concept concept, final ConceptRef fallback) {
+    if (concept != null && concept.getAttributes() != null) {
+      final Map<String, String> attrs = concept.getAttributes();
+      String shortName = attrs.get(LoincConstants.ATTR_SHORT_COMMON_NAME);
+      if (StringUtility.isEmpty(shortName)) {
+        shortName = attrs.get(LoincConstants.ATTR_SHORTNAME);
+      }
+      if (!StringUtility.isEmpty(shortName)) {
+        return shortName;
+      }
+    }
+    if (concept != null) {
+      for (final Term term : concept.getTerms()) {
+        if (!term.getActive() || StringUtility.isEmpty(term.getName())) {
+          continue;
+        }
+        final String termType = term.getType();
+        if (LoincConstants.TERM_TYPE_SHORT_COMMON_NAME.equals(termType)
+            || LoincConstants.TERM_TYPE_SHORTNAME.equals(termType)) {
+          return term.getName();
+        }
+      }
+    }
+    if (concept != null && !StringUtility.isEmpty(concept.getName())) {
+      return concept.getName();
+    }
+    if (fallback != null && !StringUtility.isEmpty(fallback.getName())) {
+      return fallback.getName();
+    }
+    return null;
+  }
+
+  /**
+   * Reads LOINC scale type from a concept's indexed attributes.
+   *
+   * @param concept the concept
+   * @return scale type or null
+   */
+  private static String getScaleType(final Concept concept) {
+    if (concept == null || concept.getAttributes() == null) {
+      return null;
+    }
+    final Map<String, String> attrs = concept.getAttributes();
+    String scaleTyp = attrs.get(ATTR_SCALE_TYP);
+    if (scaleTyp == null) {
+      scaleTyp = attrs.get(ATTR_LOINC_SCALE_TYP);
+    }
+    if (scaleTyp == null) {
+      scaleTyp = attrs.get("scale_typ");
+    }
+    return scaleTyp;
+  }
+
+  /**
+   * Resolves FHIR Questionnaire item type from LOINC scale type and answer options.
+   *
+   * @param memberConcept the member concept
+   * @param answerOptions the answer options
+   * @return the item type
+   */
+  private static Questionnaire.QuestionnaireItemType resolveQuestionnaireItemType(
+    final Concept memberConcept,
+    final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions) {
+    if (answerOptions != null && !answerOptions.isEmpty()) {
+      return Questionnaire.QuestionnaireItemType.CHOICE;
+    }
+    final String scaleTyp = getScaleType(memberConcept);
+    if (scaleTyp != null) {
+      final String normalized = scaleTyp.toUpperCase(Locale.ENGLISH);
+      if (normalized.contains("QN") || normalized.contains("SEMIQN")) {
+        return Questionnaire.QuestionnaireItemType.DECIMAL;
+      }
+      if (normalized.contains("QL") || normalized.equals("ORD") || normalized.equals("NAR")
+          || normalized.equals("NOM") || normalized.equals("DOC") || normalized.equals("SET")
+          || normalized.equals("MULTI")) {
+        return Questionnaire.QuestionnaireItemType.STRING;
+      }
+    }
+    return Questionnaire.QuestionnaireItemType.DECIMAL;
+  }
+
+  /**
+   * Finds questionnaire items for panel members (groups or direct questions).
    *
    * @param mainConcept the main questionnaire concept
    * @param searchService the search service
@@ -1900,42 +2347,54 @@ public final class FhirUtilityR4 {
     final List<Questionnaire.QuestionnaireItemComponent> allItems = new ArrayList<>();
 
     try {
-      // Find has_member relationships from the main concept
-      final String hasMemberQuery = "from.code:" + StringUtility.escapeQuery(mainConcept.getCode())
-          + " AND additionalType:has_member";
-      final List<ConceptRelationship> hasMemberRels =
-          searchService.findAll(hasMemberQuery, null, ConceptRelationship.class);
+      List<ConceptRelationship> memberRels = findPanelMemberRelationships(mainConcept.getCode(),
+          searchService, terminology);
 
-      for (final ConceptRelationship hasMemberRel : hasMemberRels) {
-        if (hasMemberRel.getTo() != null) {
-          final String memberCode = hasMemberRel.getTo().getCode();
-          if (memberCode != null && !processedCodes.contains(memberCode)) {
+      if (memberRels.isEmpty() && !mainConcept.getChildren().isEmpty()) {
+        memberRels = new ArrayList<>();
+        for (final ConceptRef child : mainConcept.getChildren()) {
+          if (child.getCode() == null || mainConcept.getCode().equals(child.getCode())) {
+            continue;
+          }
+          final ConceptRelationship rel = new ConceptRelationship();
+          rel.setHierarchical(true);
+          rel.setAdditionalType("parent");
+          rel.setFrom(child);
+          rel.setTo(new ConceptRef(mainConcept.getCode(), mainConcept.getName()));
+          memberRels.add(rel);
+        }
+        memberRels = sortMemberRelationships(memberRels);
+      }
 
-            // Check if this member should be a group or direct question
-            final Concept memberConcept = TerminologyUtility.getConcept(searchService, "LOINC",
-                "Regenstrief Institute", latestVersion, memberCode);
+      for (final ConceptRelationship memberRel : memberRels) {
+        final ConceptRef memberRef = getMemberConceptRef(memberRel);
+        if (memberRef == null) {
+          continue;
+        }
+        final String memberCode = memberRef.getCode();
+        if (memberCode == null || processedCodes.contains(memberCode)) {
+          continue;
+        }
 
-            if (memberConcept != null) {
-              final boolean isOrganizer = isOrganizerConcept(memberConcept);
+        final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+            terminology.getAbbreviation(), terminology.getPublisher(), latestVersion, memberCode);
 
-              if (isOrganizer) {
-                // Create a group with nested questions
-                final Questionnaire.QuestionnaireItemComponent groupItem = createGroupItem(
-                    hasMemberRel, searchService, terminology, processedCodes, latestVersion);
-                if (groupItem != null) {
-                  allItems.add(groupItem);
-                  processedCodes.add(memberCode);
-                }
-              } else {
-                // Create a direct question with answer options
-                final Questionnaire.QuestionnaireItemComponent questionItem =
-                    createDirectQuestionItem(hasMemberRel, searchService, terminology,
-                        processedCodes, latestVersion);
-                if (questionItem != null) {
-                  allItems.add(questionItem);
-                  processedCodes.add(memberCode);
-                }
-              }
+        if (memberConcept != null) {
+          final boolean isOrganizer = isOrganizerConcept(memberConcept);
+
+          if (isOrganizer) {
+            final Questionnaire.QuestionnaireItemComponent groupItem = createGroupItem(memberRel,
+                searchService, terminology, processedCodes, latestVersion);
+            if (groupItem != null) {
+              allItems.add(groupItem);
+              processedCodes.add(memberCode);
+            }
+          } else {
+            final Questionnaire.QuestionnaireItemComponent questionItem = createDirectQuestionItem(
+                memberRel, searchService, terminology, processedCodes, latestVersion);
+            if (questionItem != null) {
+              allItems.add(questionItem);
+              processedCodes.add(memberCode);
             }
           }
         }
@@ -1969,12 +2428,17 @@ public final class FhirUtilityR4 {
     final Questionnaire.QuestionnaireItemComponent groupItem =
         new Questionnaire.QuestionnaireItemComponent();
 
-    if (hasMemberRel.getTo() != null) {
-      final ConceptRef toConcept = hasMemberRel.getTo();
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+          terminology.getAbbreviation(), terminology.getPublisher(), latestVersion,
+          toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
 
       // Set group properties
       groupItem.setLinkId(toConcept.getCode());
-      groupItem.setText(toConcept.getName());
+      groupItem.setText(displayName);
       groupItem.setType(Questionnaire.QuestionnaireItemType.GROUP);
       groupItem.setRequired(true);
 
@@ -1995,7 +2459,7 @@ public final class FhirUtilityR4 {
           enableWhen.setOperator(Questionnaire.QuestionnaireItemOperator.EQUAL);
 
           final Coding answerCoding = new Coding();
-          answerCoding.setSystem("http://loinc.org");
+          answerCoding.setSystem(LoincConstants.LOINC_URI);
           answerCoding.setCode("LA33-6");
           enableWhen.setAnswer(answerCoding);
 
@@ -2007,7 +2471,7 @@ public final class FhirUtilityR4 {
       final Coding coding = new Coding();
       coding.setSystem(terminology.getUri());
       coding.setCode(toConcept.getCode());
-      coding.setDisplay(toConcept.getName());
+      coding.setDisplay(displayName);
       groupItem.addCode(coding);
 
       // Find questions for this group
@@ -2043,29 +2507,28 @@ public final class FhirUtilityR4 {
     final Set<String> groupProcessedCodes = new HashSet<>();
 
     try {
-      // Find has_member relationships from the group concept
-      final String hasMemberQuery =
-          "from.code:" + StringUtility.escapeQuery(groupCode) + " AND additionalType:has_member";
-      final List<ConceptRelationship> hasMemberRels =
-          searchService.findAll(hasMemberQuery, null, ConceptRelationship.class);
+      final List<ConceptRelationship> memberRels =
+          findPanelMemberRelationships(groupCode, searchService, terminology);
 
-      // Debug logging to see what we're finding
       final Logger logger = LoggerFactory.getLogger(FhirUtilityR4.class);
-      logger.debug("Found {} has_member relationships for group {}: {}", hasMemberRels.size(),
+      logger.debug("Found {} panel member relationships for group {}: {}", memberRels.size(),
           groupCode,
-          hasMemberRels.stream().map(rel -> rel.getTo() != null ? rel.getTo().getCode() : "null")
-              .collect(Collectors.joining(", ")));
+          memberRels.stream().map(rel -> {
+            final ConceptRef ref = getMemberConceptRef(rel);
+            return ref != null ? ref.getCode() : "null";
+          }).collect(Collectors.joining(", ")));
 
-      for (final ConceptRelationship hasMemberRel : hasMemberRels) {
-        if (hasMemberRel.getTo() != null) {
-          final String questionCode = hasMemberRel.getTo().getCode();
+      for (final ConceptRelationship hasMemberRel : memberRels) {
+        final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+        if (memberRef != null) {
+          final String questionCode = memberRef.getCode();
           if (questionCode != null && !groupProcessedCodes.contains(questionCode)) {
             // Filter for "Intensity of ideation" group to match master file
             // structure
             if (groupCode.equals("93303-6")) {
               // Filter out description items to match master file (12 items
               // instead of 14)
-              final String questionText = hasMemberRel.getTo().getName();
+              final String questionText = memberRef.getName();
               if (questionText != null && questionText.contains("description")) {
                 logger.debug("Filtering out description item: {} - not in master file structure",
                     questionCode);
@@ -2123,34 +2586,33 @@ public final class FhirUtilityR4 {
     final Questionnaire.QuestionnaireItemComponent questionItem =
         new Questionnaire.QuestionnaireItemComponent();
 
-    if (hasMemberRel.getTo() != null) {
-      final ConceptRef toConcept = hasMemberRel.getTo();
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept =
+          TerminologyUtility.getConcept(searchService, terminology.getAbbreviation(),
+              terminology.getPublisher(), terminology.getVersion(), toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
 
       // Set question properties
       questionItem.setLinkId(toConcept.getCode());
-      questionItem.setText(toConcept.getName());
+      questionItem.setText(displayName);
       questionItem.setRepeats(false);
 
       // Add coding
       final Coding coding = new Coding();
       coding.setSystem(terminology.getUri());
       coding.setCode(toConcept.getCode());
-      coding.setDisplay(toConcept.getName());
+      coding.setDisplay(displayName);
       questionItem.addCode(coding);
 
       // Find answer options for this question
       final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions =
           findAnswerOptionsForQuestion(toConcept.getCode(), searchService, terminology);
 
-      // Set type based on whether it has answer options
-      if (answerOptions.isEmpty()) {
-        questionItem.setType(Questionnaire.QuestionnaireItemType.DECIMAL);
-      } else {
-        questionItem.setType(Questionnaire.QuestionnaireItemType.CHOICE);
-        // Add answer options
-        for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
-          questionItem.addAnswerOption(option);
-        }
+      questionItem.setType(resolveQuestionnaireItemType(memberConcept, answerOptions));
+      for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
+        questionItem.addAnswerOption(option);
       }
     }
 
@@ -2276,34 +2738,33 @@ public final class FhirUtilityR4 {
     final Questionnaire.QuestionnaireItemComponent questionItem =
         new Questionnaire.QuestionnaireItemComponent();
 
-    if (hasMemberRel.getTo() != null) {
-      final ConceptRef toConcept = hasMemberRel.getTo();
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+          terminology.getAbbreviation(), terminology.getPublisher(), latestVersion,
+          toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
 
       // Set question properties
       questionItem.setLinkId(toConcept.getCode());
-      questionItem.setText(toConcept.getName());
+      questionItem.setText(displayName);
       questionItem.setRepeats(false);
 
       // Add coding
       final Coding coding = new Coding();
       coding.setSystem(terminology.getUri());
       coding.setCode(toConcept.getCode());
-      coding.setDisplay(toConcept.getName());
+      coding.setDisplay(displayName);
       questionItem.addCode(coding);
 
       // Find answer options for this question
       final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions =
           findAnswerOptionsForQuestion(toConcept.getCode(), searchService, terminology);
 
-      // Set type based on whether it has answer options
-      if (answerOptions.isEmpty()) {
-        questionItem.setType(Questionnaire.QuestionnaireItemType.DECIMAL);
-      } else {
-        questionItem.setType(Questionnaire.QuestionnaireItemType.CHOICE);
-        // Add answer options
-        for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
-          questionItem.addAnswerOption(option);
-        }
+      questionItem.setType(resolveQuestionnaireItemType(memberConcept, answerOptions));
+      for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
+        questionItem.addAnswerOption(option);
       }
     }
 

--- a/src/main/java/com/wci/termhub/fhir/rest/r5/FhirUtilityR5.java
+++ b/src/main/java/com/wci/termhub/fhir/rest/r5/FhirUtilityR5.java
@@ -1192,11 +1192,12 @@ public final class FhirUtilityR5 {
    * @param subset the subset
    * @param members the members
    * @param metaFlag the meta flag
+   * @param searchService the search service (used to resolve copyright from source terminology)
    * @return the value set
    * @throws Exception the exception
    */
   public static ValueSet toR5ValueSet(final Subset subset, final List<SubsetMember> members,
-    final boolean metaFlag) throws Exception {
+    final boolean metaFlag, final EntityRepositoryService searchService) throws Exception {
 
     final ValueSet valueSet = new ValueSet();
     valueSet.setId(subset.getId());
@@ -1222,6 +1223,8 @@ public final class FhirUtilityR5 {
     }
     valueSet.setDescription(subset.getDescription());
     valueSet.setStatus(PublicationStatus.ACTIVE);
+
+    applyCopyrightFromTerminology(valueSet, subset, searchService);
 
     // Set experimental from attributes if present, else fallback
     final String experimentalStr = subset.getAttributes() != null
@@ -1272,6 +1275,34 @@ public final class FhirUtilityR5 {
     valueSet.getMeta().setLastUpdated(DateUtility.parseToUtcDate(subset.getCreated()));
 
     return valueSet;
+  }
+
+  /**
+   * Sets ValueSet copyright from source terminology when available, otherwise from subset
+   * attributes (preserved at import).
+   *
+   * @param valueSet the value set
+   * @param subset the subset
+   * @param searchService the search service
+   * @throws Exception the exception
+   */
+  private static void applyCopyrightFromTerminology(final ValueSet valueSet, final Subset subset,
+    final EntityRepositoryService searchService) throws Exception {
+
+    String copyright = null;
+    if (searchService != null && subset.getFromTerminology() != null) {
+      final Terminology terminology = TerminologyUtility.getTerminology(searchService,
+          subset.getFromTerminology(), subset.getFromPublisher(), subset.getFromVersion(), false);
+      if (terminology != null && terminology.getAttributes() != null) {
+        copyright = terminology.getAttributes().get("copyright");
+      }
+    }
+    if (copyright == null && subset.getAttributes() != null) {
+      copyright = subset.getAttributes().get("copyright");
+    }
+    if (copyright != null) {
+      valueSet.setCopyright(copyright);
+    }
   }
 
   /**

--- a/src/main/java/com/wci/termhub/fhir/rest/r5/FhirUtilityR5.java
+++ b/src/main/java/com/wci/termhub/fhir/rest/r5/FhirUtilityR5.java
@@ -90,6 +90,10 @@ import com.wci.termhub.util.ThreadLocalMapper;
 import ca.uhn.fhir.rest.param.NumberParam;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Comparator;
+import java.util.HashSet;
+import org.hl7.fhir.r5.model.Questionnaire;
+import com.wci.termhub.fhir.util.LoincConstants;
 
 /**
  * Utility for fhir data building.
@@ -1045,13 +1049,16 @@ public final class FhirUtilityR5 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id (e.g. LL1162-8, LG51018-6-2.78)
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param metaFlag when true, add fromTerminology/fromPublisher/fromVersion and loincLllgId tags
    * @return the value set
    */
   public static ValueSet toR5LllgValueSet(final Terminology terminology, final String lllgId,
-    final boolean metaFlag) {
+    final String valueSetId, final boolean metaFlag) {
     final ValueSet set = new ValueSet();
-    set.setId(lllgId);
+    if (valueSetId != null) {
+      set.setId(valueSetId);
+    }
     set.setUrl(terminology.getUri() + "?fhir_vs=" + lllgId);
     set.setVersion(terminology.getVersion());
     set.setPublisher(terminology.getPublisher());
@@ -1079,7 +1086,7 @@ public final class FhirUtilityR5 {
   /**
    * Builds a minimal R5 ValueSet for a LOINC LL/LG concept found during enumeration. Sets name and
    * title from the concept's name in addition to the fields set by
-   * {@link #toR5LllgValueSet(Terminology, String, boolean)}.
+   * {@link #toR5LllgValueSet(Terminology, String, String, boolean)}.
    *
    * @param terminology LOINC terminology
    * @param concept the LL or LG concept (code used as lllgId, name used as title/name)
@@ -1088,12 +1095,34 @@ public final class FhirUtilityR5 {
    */
   public static ValueSet toR5LllgValueSetFromConcept(final Terminology terminology,
     final Concept concept, final boolean metaFlag) {
-    final ValueSet set = toR5LllgValueSet(terminology, concept.getCode(), metaFlag);
+    final ValueSet set =
+        toR5LllgValueSet(terminology, concept.getCode(), concept.getId(), metaFlag);
     if (concept.getName() != null) {
       set.setName(concept.getName());
       set.setTitle(concept.getName());
     }
     return set;
+  }
+
+  /**
+   * Returns true when the id search parameter matches a ValueSet id or its loincLllgId meta tag.
+   *
+   * @param idValue the _id search value
+   * @param vs the value set
+   * @return true if matches
+   */
+  public static boolean matchesLllgValueSetId(final String idValue, final ValueSet vs) {
+    if (idValue == null || vs == null) {
+      return idValue == null;
+    }
+    if (idValue.equals(vs.getId())) {
+      return true;
+    }
+    if (vs.getMeta() != null) {
+      return vs.getMeta().getTag().stream()
+          .anyMatch(t -> META_LOINC_LLLG_ID.equals(t.getSystem()) && idValue.equals(t.getCode()));
+    }
+    return false;
   }
 
   /**
@@ -1136,12 +1165,13 @@ public final class FhirUtilityR5 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id (e.g. LL1162-8, LG51018-6-2.78)
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param composeStructure partitioned compose structure from direct members
    * @return the value set with compose.include set, no expansion
    */
   public static ValueSet toR5LllgValueSetWithComposeOnly(final Terminology terminology,
-    final String lllgId, final LllgComposeStructure composeStructure) {
-    final ValueSet set = toR5LllgValueSet(terminology, lllgId, false);
+    final String lllgId, final String valueSetId, final LllgComposeStructure composeStructure) {
+    final ValueSet set = toR5LllgValueSet(terminology, lllgId, valueSetId, false);
     setR5LllgCompose(set, terminology.getUri(), composeStructure);
     return set;
   }
@@ -1152,6 +1182,7 @@ public final class FhirUtilityR5 {
    *
    * @param terminology LOINC terminology
    * @param lllgId the LL or LG id
+   * @param valueSetId the FHIR resource id (Concept UUID)
    * @param composeStructure partitioned compose from direct members
    * @param leafMembers paginated leaf concepts for expansion.contains
    * @param expansionTotal total leaf count before pagination
@@ -1160,10 +1191,10 @@ public final class FhirUtilityR5 {
    * @return the value set with compose.include and expansion.contains set
    */
   public static ValueSet toR5LllgValueSetWithMembers(final Terminology terminology,
-    final String lllgId, final LllgComposeStructure composeStructure,
+    final String lllgId, final String valueSetId, final LllgComposeStructure composeStructure,
     final List<Concept> leafMembers, final int expansionTotal, final int expansionOffset,
     final int expansionCount) {
-    final ValueSet set = toR5LllgValueSet(terminology, lllgId, false);
+    final ValueSet set = toR5LllgValueSet(terminology, lllgId, valueSetId, false);
     final String systemUri = terminology.getUri();
     setR5LllgCompose(set, systemUri, composeStructure);
     if (systemUri == null || leafMembers == null) {
@@ -1743,5 +1774,1046 @@ public final class FhirUtilityR5 {
       bundle.addEntry(component);
     }
     return bundle;
+  }
+
+  private static Date resolveTerminologyReleaseDate(final Terminology terminology)
+    throws Exception {
+    if (terminology == null) {
+      return null;
+    }
+    final String releaseDate = terminology.getReleaseDate();
+    if (releaseDate == null || releaseDate.isEmpty()) {
+      return null;
+    }
+    if (releaseDate.contains("T")) {
+      return Date.from(Instant.parse(releaseDate));
+    }
+    return DateUtility.DATE_YYYY_MM_DD_DASH.parse(releaseDate);
+  }
+
+  /**
+   * Builds Questionnaire meta consistent with CodeSystem: versionId, lastUpdated, optional
+   * originalId tag.
+   *
+   * @param terminology the terminology (optional)
+   * @param concept the concept (optional)
+   * @return the meta
+   */
+  private static Meta buildQuestionnaireMeta(final Terminology terminology, final Concept concept)
+    throws Exception {
+    final Meta meta = new Meta();
+    meta.setVersionId("1");
+    Date lastUpdated = resolveTerminologyReleaseDate(terminology);
+    if (lastUpdated == null && terminology != null && terminology.getCreated() != null) {
+      lastUpdated = DateUtility.parseToUtcDate(terminology.getCreated());
+    }
+    if (lastUpdated == null && concept != null) {
+      if (concept.getModified() != null) {
+        lastUpdated = DateUtility.parseToUtcDate(concept.getModified());
+      } else if (concept.getCreated() != null) {
+        lastUpdated = DateUtility.parseToUtcDate(concept.getCreated());
+      }
+    }
+    if (lastUpdated != null) {
+      meta.setLastUpdated(lastUpdated);
+    }
+    if (concept != null && concept.getAttributes() != null
+        && concept.getAttributes().containsKey("originalId")) {
+      meta.addTag("originalId", concept.getAttributes().get("originalId"), null);
+    } else if (terminology != null && terminology.getAttributes() != null
+        && terminology.getAttributes().containsKey("originalId")) {
+      meta.addTag("originalId", terminology.getAttributes().get("originalId"), null);
+    }
+    return meta;
+  }
+
+  /**
+   * Resolves terminology copyright (same source as CodeSystem).
+   *
+   * @param terminology the terminology
+   * @param searchService the search service (optional, reloads full record by id)
+   * @return copyright text or null
+   * @throws Exception the exception
+   */
+  private static String resolveTerminologyCopyright(final Terminology terminology,
+    final EntityRepositoryService searchService) throws Exception {
+    if (terminology == null) {
+      return null;
+    }
+    Terminology source = terminology;
+    if (searchService != null && terminology.getId() != null) {
+      final Terminology full = searchService.get(terminology.getId(), Terminology.class);
+      if (full != null) {
+        source = full;
+      }
+    }
+    final String copyright = source.getAttributes().get("copyright");
+    return StringUtility.isEmpty(copyright) ? null : copyright;
+  }
+
+  /**
+   * Sets Questionnaire copyright from terminology attributes when available.
+   *
+   * @param questionnaire the questionnaire
+   * @param terminology the terminology
+   * @param searchService the search service (optional)
+   * @throws Exception the exception
+   */
+  private static void applyQuestionnaireCopyright(final Questionnaire questionnaire,
+    final Terminology terminology, final EntityRepositoryService searchService) throws Exception {
+    final String copyright = resolveTerminologyCopyright(terminology, searchService);
+    if (copyright != null) {
+      questionnaire.setCopyright(copyright);
+    }
+  }
+
+  /**
+   * Converts a Terminology to a FHIR R5 Questionnaire.
+   *
+   * @param terminology the Terminology
+   * @param metaFlag the meta flag
+   * @return the FHIR R5 Questionnaire
+   * @throws Exception the exception
+   */
+  public static Questionnaire toR5Questionnaire(final Terminology terminology,
+    final boolean metaFlag) throws Exception {
+
+    final Questionnaire questionnaire = new Questionnaire();
+    questionnaire.setId(terminology.getId() + "_entire");
+    questionnaire.setUrl(terminology.getUri() + "?fhir_questionnaire");
+    questionnaire.setVersion(terminology.getVersion());
+    questionnaire.setName("Q " + terminology.getName());
+    questionnaire.setTitle(terminology.getAbbreviation() + "-ENTIRE");
+    questionnaire.setStatus(PublicationStatus.ACTIVE);
+    questionnaire
+        .setDescription("Questionnaire representing the entire contents of this code system");
+    final Date releaseAsDate = resolveTerminologyReleaseDate(terminology);
+    if (releaseAsDate != null) {
+      questionnaire.setDate(releaseAsDate);
+    }
+    questionnaire.setPublisher(terminology.getPublisher());
+    applyQuestionnaireCopyright(questionnaire, terminology, null);
+
+    final Meta meta = buildQuestionnaireMeta(terminology, null);
+    if (metaFlag) {
+      meta.addTag("fromTerminology", terminology.getAbbreviation(), null)
+          .addTag("fromPublisher", terminology.getPublisher(), null)
+          .addTag("fromVersion", terminology.getVersion(), null)
+          .addTag("includesUri", terminology.getUri(), null);
+    }
+    questionnaire.setMeta(meta);
+
+    return questionnaire;
+  }
+
+  /**
+   * Converts a LOINC Concept to a FHIR R5 Questionnaire. This is the primary method for creating
+   * questionnaires from LOINC concepts.
+   *
+   * @param concept the LOINC Concept
+   * @param searchService the search service
+   * @return the FHIR R5 Questionnaire
+   * @throws Exception the exception
+   */
+  public static Questionnaire toR5Questionnaire(final Concept concept,
+    final EntityRepositoryService searchService) throws Exception {
+    return toR5Questionnaire(concept, searchService, null);
+  }
+
+  /**
+   * Converts a LOINC Concept to a FHIR R5 Questionnaire. This is the primary method for creating
+   * questionnaires from LOINC concepts.
+   *
+   * @param concept the LOINC Concept
+   * @param searchService the search service
+   * @param terminology the LOINC terminology (for meta.lastUpdated)
+   * @return the FHIR R5 Questionnaire
+   * @throws Exception the exception
+   */
+  public static Questionnaire toR5Questionnaire(final Concept concept,
+    final EntityRepositoryService searchService, final Terminology terminology) throws Exception {
+
+    final Questionnaire questionnaire = new Questionnaire();
+
+    // Set basic metadata
+    questionnaire.setId(concept.getCode());
+
+    // Build URL from terminology information
+    final String systemUri = getSystemUriFromTerminology(searchService, concept.getTerminology(),
+        concept.getPublisher(), concept.getVersion());
+    questionnaire.setUrl(systemUri + "/q/" + concept.getCode());
+
+    final String shortCommonName = resolveLoincShortCommonName(concept);
+    final String title =
+        !StringUtility.isEmpty(shortCommonName) ? shortCommonName : concept.getName();
+    final String name = !StringUtility.isEmpty(shortCommonName) ? toQuestionnaireName(shortCommonName)
+        : concept.getName();
+    questionnaire.setName(name);
+    questionnaire.setTitle(title);
+    questionnaire.setStatus(PublicationStatus.DRAFT);
+
+    // Set description from definitions if available, or use name as fallback
+    String description = concept.getName();
+    if (concept.getDefinitions() != null && !concept.getDefinitions().isEmpty()) {
+      description = concept.getDefinitions().get(0).getDefinition();
+    }
+    questionnaire.setDescription(description);
+
+    // Set publisher from concept data
+    questionnaire.setPublisher(concept.getPublisher());
+
+    // Set subject type to Patient for most questionnaires
+    final List<CodeType> subjectTypes = new ArrayList<>();
+    subjectTypes.add(new CodeType("Patient"));
+    questionnaire.setSubjectType(subjectTypes);
+
+    // Add coding to questionnaire.code field using database information
+    final Coding coding = new Coding();
+    coding.setSystem(systemUri);
+    coding.setCode(concept.getCode());
+    coding.setDisplay(title);
+    questionnaire.addCode(coding);
+
+    // Add contact information using concept data
+    final ContactDetail contact = new ContactDetail();
+    contact.setName(concept.getPublisher());
+    final ContactPoint telecom = new ContactPoint();
+    telecom.setSystem(ContactPoint.ContactPointSystem.URL);
+    telecom.setValue(systemUri);
+    contact.addTelecom(telecom);
+    questionnaire.addContact(contact);
+
+    Terminology copyrightTerminology = terminology;
+    if (copyrightTerminology == null && searchService != null) {
+      copyrightTerminology = TerminologyUtility.getTerminology(searchService,
+          concept.getTerminology(), concept.getPublisher(), concept.getVersion());
+    }
+    applyQuestionnaireCopyright(questionnaire, copyrightTerminology, searchService);
+
+    questionnaire.setMeta(buildQuestionnaireMeta(terminology, concept));
+
+    return questionnaire;
+  }
+
+  /**
+   * Populates a Questionnaire with questions and answers based on LOINC relationships. This method
+   * uses the concept's existing relationships to create questionnaire items.
+   *
+   * @param questionnaire the Questionnaire to populate
+   * @param searchService the search service for data access
+   * @param terminology the terminology
+   * @throws Exception the exception
+   */
+  public static void populateQuestionnaire(final Questionnaire questionnaire,
+    final EntityRepositoryService searchService, final Terminology terminology) throws Exception {
+
+    // Clear any existing items
+    questionnaire.getItem().clear();
+
+    // Extract LOINC code from questionnaire ID
+    final String loincCode = questionnaire.getId();
+    if (loincCode == null) {
+      return;
+    }
+
+    try {
+
+      // Track all processed codes to prevent duplicates at any level
+      final Set<String> processedCodes = new HashSet<>();
+      processedCodes.add(loincCode); // Add the main questionnaire code
+
+      // Get the main concept to find its relationships
+      final Concept mainConcept =
+          TerminologyUtility.getConcept(searchService, terminology.getAbbreviation(),
+              terminology.getPublisher(), terminology.getVersion(), loincCode);
+      if (mainConcept == null) {
+        return;
+      }
+
+      // Find panel members via has_member or hierarchical parent relationships
+      final List<Questionnaire.QuestionnaireItemComponent> groupItems = findGroupConcepts(
+          mainConcept, searchService, terminology, processedCodes, terminology.getVersion());
+
+      // Add group items to questionnaire
+      for (final Questionnaire.QuestionnaireItemComponent groupItem : groupItems) {
+        questionnaire.addItem(groupItem);
+      }
+
+    } catch (final Exception e) {
+      // Log error but don't fail the entire questionnaire
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.warn("Failed to populate questionnaire {}: {}", loincCode, e.getMessage());
+    }
+  }
+
+  /** LOINC scale type attribute keys on indexed concepts. */
+  private static final String ATTR_SCALE_TYP = "SCALE_TYP";
+
+  /** Alternate LOINC scale type attribute key. */
+  private static final String ATTR_LOINC_SCALE_TYP = "LOINC_SCALE_TYP";
+
+  /** Panel member sequence on relationships. */
+  private static final String ATTR_SEQ_NO = "SEQ_NO";
+
+  /**
+   * Finds panel member relationships for a questionnaire/panel code. Prefers outbound
+   * {@code member} edges (full LOINC), then {@code has_member} (sandbox); falls back to
+   * inbound hierarchical {@code parent} edges (child {@code from} → panel {@code to}).
+   *
+   * @param panelCode the panel or questionnaire code
+   * @param searchService the search service
+   * @param terminology the LOINC terminology
+   * @return sorted member relationships (may be empty)
+   * @throws Exception the exception
+   */
+  private static List<ConceptRelationship> findPanelMemberRelationships(final String panelCode,
+    final EntityRepositoryService searchService, final Terminology terminology) throws Exception {
+
+    final String termQuery = TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), terminology.getVersion());
+
+    final String memberQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("from.code", panelCode),
+        StringUtility.escapeKeywordField("additionalType", LoincConstants.LOINC_REL_PANEL_MEMBER));
+    final List<ConceptRelationship> memberRels =
+        searchService.findAll(memberQuery, null, ConceptRelationship.class);
+    if (!memberRels.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, memberRels));
+    }
+
+    final String hasMemberQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("from.code", panelCode),
+        StringUtility.escapeKeywordField("additionalType", LoincConstants.LOINC_REL_HAS_MEMBER));
+    final List<ConceptRelationship> hasMemberRels =
+        searchService.findAll(hasMemberQuery, null, ConceptRelationship.class);
+    if (!hasMemberRels.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, hasMemberRels));
+    }
+
+    final String childQuery = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("to.code", panelCode), "hierarchical:true", "active:true");
+    final List<ConceptRelationship> childRels =
+        searchService.findAll(childQuery, null, ConceptRelationship.class);
+
+    final List<ConceptRelationship> filtered = new ArrayList<>();
+    for (final ConceptRelationship rel : childRels) {
+      if (rel.getHierarchical() == null || !rel.getHierarchical()) {
+        continue;
+      }
+      final ConceptRef memberRef = rel.getFrom();
+      if (memberRef == null || memberRef.getCode() == null || panelCode.equals(memberRef.getCode())) {
+        continue;
+      }
+      filtered.add(rel);
+    }
+    if (!filtered.isEmpty()) {
+      return sortMemberRelationships(filterPanelMemberRelationships(panelCode, filtered));
+    }
+
+    final String parentClause =
+        "parents.code:" + StringUtility.escapeQuery(panelCode);
+    final String excludePanel = "-code:" + StringUtility.escapeQuery(panelCode);
+    final String conceptQuery =
+        StringUtility.composeQuery("AND", termQuery, parentClause, excludePanel);
+    final SearchParameters params = new SearchParameters(conceptQuery, 500, 0);
+    final ResultList<Concept> childConcepts = searchService.find(params, Concept.class);
+
+    final List<ConceptRelationship> fromParents = new ArrayList<>();
+    for (final Concept child : childConcepts.getItems()) {
+      if (child.getCode() == null || panelCode.equals(child.getCode())) {
+        continue;
+      }
+      final ConceptRelationship rel = new ConceptRelationship();
+      rel.setHierarchical(true);
+      rel.setAdditionalType("parent");
+      rel.setFrom(new ConceptRef(child.getCode(), child.getName()));
+      rel.setTo(new ConceptRef(panelCode, null));
+      fromParents.add(rel);
+    }
+    return sortMemberRelationships(filterPanelMemberRelationships(panelCode, fromParents));
+  }
+
+  /**
+   * Drops self-references and LOINC part (LP*) targets from panel member relationships.
+   *
+   * @param panelCode the panel code
+   * @param relationships the candidate relationships
+   * @return filtered relationships
+   */
+  private static List<ConceptRelationship> filterPanelMemberRelationships(final String panelCode,
+    final List<ConceptRelationship> relationships) {
+    if (relationships == null || relationships.isEmpty()) {
+      return List.of();
+    }
+    final List<ConceptRelationship> filtered = new ArrayList<>();
+    for (final ConceptRelationship rel : relationships) {
+      final ConceptRef memberRef = getMemberConceptRef(rel);
+      if (memberRef == null || memberRef.getCode() == null) {
+        continue;
+      }
+      final String memberCode = memberRef.getCode();
+      if (panelCode.equals(memberCode) || memberCode.startsWith("LP")) {
+        continue;
+      }
+      filtered.add(rel);
+    }
+    return filtered;
+  }
+
+  /**
+   * Returns the member concept reference for a panel membership relationship.
+   *
+   * @param rel the relationship
+   * @return the member concept ref, or null
+   */
+  private static ConceptRef getMemberConceptRef(final ConceptRelationship rel) {
+    if (rel == null) {
+      return null;
+    }
+    final String additionalType = rel.getAdditionalType();
+    if (LoincConstants.LOINC_REL_HAS_MEMBER.equals(additionalType)
+        || LoincConstants.LOINC_REL_PANEL_MEMBER.equals(additionalType)) {
+      return rel.getTo();
+    }
+    if (Boolean.TRUE.equals(rel.getHierarchical())) {
+      return rel.getFrom();
+    }
+    return rel.getTo();
+  }
+
+  /**
+   * Sorts panel member relationships by sequence metadata when present.
+   *
+   * @param relationships the relationships
+   * @return sorted list
+   */
+  private static List<ConceptRelationship> sortMemberRelationships(
+    final List<ConceptRelationship> relationships) {
+    if (relationships == null || relationships.size() <= 1) {
+      return relationships == null ? List.of() : relationships;
+    }
+    final List<ConceptRelationship> sorted = new ArrayList<>(relationships);
+    sorted.sort(Comparator.comparingInt(FhirUtilityR5::relationshipSequenceNumber)
+        .thenComparing(rel -> {
+          final ConceptRef memberRef = getMemberConceptRef(rel);
+          return memberRef == null || memberRef.getCode() == null ? "" : memberRef.getCode();
+        }));
+    return sorted;
+  }
+
+  /**
+   * Sequence number for a panel member relationship.
+   *
+   * @param rel the relationship
+   * @return sequence number or max value if unknown
+   */
+  private static int relationshipSequenceNumber(final ConceptRelationship rel) {
+    if (rel == null) {
+      return Integer.MAX_VALUE;
+    }
+    if (rel.getAttributes() != null) {
+      final String seq = rel.getAttributes().get(ATTR_SEQ_NO);
+      if (seq != null) {
+        try {
+          return Integer.parseInt(seq);
+        } catch (final NumberFormatException e) {
+          // fall through
+        }
+      }
+    }
+    if (rel.getGroup() != null) {
+      try {
+        return Integer.parseInt(rel.getGroup());
+      } catch (final NumberFormatException e) {
+        // fall through
+      }
+    }
+    final ConceptRef memberRef = getMemberConceptRef(rel);
+    if (memberRef != null && memberRef.getCode() != null) {
+      return Integer.MAX_VALUE - 1;
+    }
+    return Integer.MAX_VALUE;
+  }
+
+  /**
+   * Resolves the LOINC short common name for a concept (panel or member).
+   *
+   * @param concept the concept
+   * @return short common name or null
+   */
+  private static String resolveLoincShortCommonName(final Concept concept) {
+    return resolveLoincDisplayName(concept, null);
+  }
+
+  /**
+   * Converts a LOINC short common name to a FHIR Questionnaire.name (non-alphanumeric → underscore).
+   *
+   * @param shortCommonName the short common name
+   * @return machine name
+   */
+  private static String toQuestionnaireName(final String shortCommonName) {
+    if (StringUtility.isEmpty(shortCommonName)) {
+      return shortCommonName;
+    }
+    return shortCommonName.replaceAll("[^a-zA-Z0-9]+", "_").replaceAll("^_+|_+$", "");
+  }
+
+  /**
+   * Resolves the LOINC short common name for questionnaire item display.
+   *
+   * @param concept the loaded member concept (optional)
+   * @param fallback the member concept ref from a relationship (optional)
+   * @return display text
+   */
+  private static String resolveLoincDisplayName(final Concept concept, final ConceptRef fallback) {
+    if (concept != null && concept.getAttributes() != null) {
+      final Map<String, String> attrs = concept.getAttributes();
+      String shortName = attrs.get(LoincConstants.ATTR_SHORT_COMMON_NAME);
+      if (StringUtility.isEmpty(shortName)) {
+        shortName = attrs.get(LoincConstants.ATTR_SHORTNAME);
+      }
+      if (!StringUtility.isEmpty(shortName)) {
+        return shortName;
+      }
+    }
+    if (concept != null) {
+      for (final Term term : concept.getTerms()) {
+        if (!term.getActive() || StringUtility.isEmpty(term.getName())) {
+          continue;
+        }
+        final String termType = term.getType();
+        if (LoincConstants.TERM_TYPE_SHORT_COMMON_NAME.equals(termType)
+            || LoincConstants.TERM_TYPE_SHORTNAME.equals(termType)) {
+          return term.getName();
+        }
+      }
+    }
+    if (concept != null && !StringUtility.isEmpty(concept.getName())) {
+      return concept.getName();
+    }
+    if (fallback != null && !StringUtility.isEmpty(fallback.getName())) {
+      return fallback.getName();
+    }
+    return null;
+  }
+
+  /**
+   * Reads LOINC scale type from a concept's indexed attributes.
+   *
+   * @param concept the concept
+   * @return scale type or null
+   */
+  private static String getScaleType(final Concept concept) {
+    if (concept == null || concept.getAttributes() == null) {
+      return null;
+    }
+    final Map<String, String> attrs = concept.getAttributes();
+    String scaleTyp = attrs.get(ATTR_SCALE_TYP);
+    if (scaleTyp == null) {
+      scaleTyp = attrs.get(ATTR_LOINC_SCALE_TYP);
+    }
+    if (scaleTyp == null) {
+      scaleTyp = attrs.get("scale_typ");
+    }
+    return scaleTyp;
+  }
+
+  /**
+   * Resolves FHIR Questionnaire item type from LOINC scale type and answer options.
+   *
+   * @param memberConcept the member concept
+   * @param answerOptions the answer options
+   * @return the item type
+   */
+  private static Questionnaire.QuestionnaireItemType resolveQuestionnaireItemType(
+    final Concept memberConcept,
+    final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions) {
+    if (answerOptions != null && !answerOptions.isEmpty()) {
+      return Questionnaire.QuestionnaireItemType.CODING;
+    }
+    final String scaleTyp = getScaleType(memberConcept);
+    if (scaleTyp != null) {
+      final String normalized = scaleTyp.toUpperCase(Locale.ENGLISH);
+      if (normalized.contains("QN") || normalized.contains("SEMIQN")) {
+        return Questionnaire.QuestionnaireItemType.DECIMAL;
+      }
+      if (normalized.contains("QL") || normalized.equals("ORD") || normalized.equals("NAR")
+          || normalized.equals("NOM") || normalized.equals("DOC") || normalized.equals("SET")
+          || normalized.equals("MULTI")) {
+        return Questionnaire.QuestionnaireItemType.STRING;
+      }
+    }
+    return Questionnaire.QuestionnaireItemType.DECIMAL;
+  }
+
+  /**
+   * Finds questionnaire items for panel members (groups or direct questions).
+   *
+   * @param mainConcept the main questionnaire concept
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param processedCodes set of already processed codes
+   * @param latestVersion the latest version
+   * @return list of group questionnaire item components
+   * @throws Exception the exception
+   */
+  private static List<Questionnaire.QuestionnaireItemComponent> findGroupConcepts(
+    final Concept mainConcept, final EntityRepositoryService searchService,
+    final Terminology terminology, final Set<String> processedCodes, final String latestVersion)
+    throws Exception {
+
+    final List<Questionnaire.QuestionnaireItemComponent> allItems = new ArrayList<>();
+
+    try {
+      List<ConceptRelationship> memberRels = findPanelMemberRelationships(mainConcept.getCode(),
+          searchService, terminology);
+
+      if (memberRels.isEmpty() && !mainConcept.getChildren().isEmpty()) {
+        memberRels = new ArrayList<>();
+        for (final ConceptRef child : mainConcept.getChildren()) {
+          if (child.getCode() == null || mainConcept.getCode().equals(child.getCode())) {
+            continue;
+          }
+          final ConceptRelationship rel = new ConceptRelationship();
+          rel.setHierarchical(true);
+          rel.setAdditionalType("parent");
+          rel.setFrom(child);
+          rel.setTo(new ConceptRef(mainConcept.getCode(), mainConcept.getName()));
+          memberRels.add(rel);
+        }
+        memberRels = sortMemberRelationships(memberRels);
+      }
+
+      for (final ConceptRelationship memberRel : memberRels) {
+        final ConceptRef memberRef = getMemberConceptRef(memberRel);
+        if (memberRef == null) {
+          continue;
+        }
+        final String memberCode = memberRef.getCode();
+        if (memberCode == null || processedCodes.contains(memberCode)) {
+          continue;
+        }
+
+        final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+            terminology.getAbbreviation(), terminology.getPublisher(), latestVersion, memberCode);
+
+        if (memberConcept != null) {
+          final boolean isOrganizer = isOrganizerConcept(memberConcept);
+
+          if (isOrganizer) {
+            final Questionnaire.QuestionnaireItemComponent groupItem = createGroupItem(memberRel,
+                searchService, terminology, processedCodes, latestVersion);
+            if (groupItem != null) {
+              allItems.add(groupItem);
+              processedCodes.add(memberCode);
+            }
+          } else {
+            final Questionnaire.QuestionnaireItemComponent questionItem = createDirectQuestionItem(
+                memberRel, searchService, terminology, processedCodes, latestVersion);
+            if (questionItem != null) {
+              allItems.add(questionItem);
+              processedCodes.add(memberCode);
+            }
+          }
+        }
+      }
+
+    } catch (final Exception e) {
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.warn("Failed to find group concepts for main concept {}: {}", mainConcept.getCode(),
+          e.getMessage());
+    }
+
+    return allItems;
+  }
+
+  /**
+   * Creates a group questionnaire item from a has_member relationship.
+   *
+   * @param hasMemberRel the has_member relationship
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param processedCodes set of already processed codes
+   * @param latestVersion the latest version
+   * @return the questionnaire item component
+   * @throws Exception the exception
+   */
+  private static Questionnaire.QuestionnaireItemComponent createGroupItem(
+    final ConceptRelationship hasMemberRel, final EntityRepositoryService searchService,
+    final Terminology terminology, final Set<String> processedCodes, final String latestVersion)
+    throws Exception {
+
+    final Questionnaire.QuestionnaireItemComponent groupItem =
+        new Questionnaire.QuestionnaireItemComponent();
+
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+          terminology.getAbbreviation(), terminology.getPublisher(), latestVersion,
+          toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
+
+      // Set group properties
+      groupItem.setLinkId(toConcept.getCode());
+      groupItem.setText(displayName);
+      groupItem.setType(Questionnaire.QuestionnaireItemType.GROUP);
+      groupItem.setRequired(true);
+
+      // Add special properties for "Intensity of ideation" group (93303-6)
+      if (toConcept.getCode().equals("93303-6")) {
+        // Add enableWhen conditions based on master file
+        groupItem.setEnableBehavior(Questionnaire.EnableWhenBehavior.ANY);
+
+        // Add enableWhen conditions for questions 113944, 113952, 113947,
+        // 113951
+        final String[] enableWhenQuestions = {
+            "113944", "113952", "113947", "113951"
+        };
+        for (final String questionId : enableWhenQuestions) {
+          final Questionnaire.QuestionnaireItemEnableWhenComponent enableWhen =
+              new Questionnaire.QuestionnaireItemEnableWhenComponent();
+          enableWhen.setQuestion(questionId);
+          enableWhen.setOperator(Questionnaire.QuestionnaireItemOperator.EQUAL);
+
+          final Coding answerCoding = new Coding();
+          answerCoding.setSystem(LoincConstants.LOINC_URI);
+          answerCoding.setCode("LA33-6");
+          enableWhen.setAnswer(answerCoding);
+
+          groupItem.addEnableWhen(enableWhen);
+        }
+      }
+
+      // Add coding
+      final Coding coding = new Coding();
+      coding.setSystem(terminology.getUri());
+      coding.setCode(toConcept.getCode());
+      coding.setDisplay(displayName);
+      groupItem.addCode(coding);
+
+      // Find questions for this group
+      final List<Questionnaire.QuestionnaireItemComponent> questions =
+          findQuestionsForGroup(toConcept.getCode(), searchService, terminology, processedCodes);
+
+      for (final Questionnaire.QuestionnaireItemComponent question : questions) {
+        groupItem.addItem(question);
+      }
+    }
+
+    return groupItem;
+  }
+
+  /**
+   * Finds questions for a group via has_member relationships.
+   *
+   * @param groupCode the group LOINC code
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param processedCodes set of already processed codes
+   * @return list of question components
+   * @throws Exception the exception
+   */
+  private static List<Questionnaire.QuestionnaireItemComponent> findQuestionsForGroup(
+    final String groupCode, final EntityRepositoryService searchService,
+    final Terminology terminology, final Set<String> processedCodes) throws Exception {
+
+    final List<Questionnaire.QuestionnaireItemComponent> questions = new ArrayList<>();
+
+    // Create a separate processedCodes set for this group to avoid conflicts
+    // with main level
+    final Set<String> groupProcessedCodes = new HashSet<>();
+
+    try {
+      final List<ConceptRelationship> memberRels =
+          findPanelMemberRelationships(groupCode, searchService, terminology);
+
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.debug("Found {} panel member relationships for group {}: {}", memberRels.size(),
+          groupCode,
+          memberRels.stream().map(rel -> {
+            final ConceptRef ref = getMemberConceptRef(rel);
+            return ref != null ? ref.getCode() : "null";
+          }).collect(Collectors.joining(", ")));
+
+      for (final ConceptRelationship hasMemberRel : memberRels) {
+        final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+        if (memberRef != null) {
+          final String questionCode = memberRef.getCode();
+          if (questionCode != null && !groupProcessedCodes.contains(questionCode)) {
+            // Filter for "Intensity of ideation" group to match master file
+            // structure
+            if (groupCode.equals("93303-6")) {
+              // Filter out description items to match master file (12 items
+              // instead of 14)
+              final String questionText = memberRef.getName();
+              if (questionText != null && questionText.contains("description")) {
+                logger.debug("Filtering out description item: {} - not in master file structure",
+                    questionCode);
+                continue;
+              }
+            }
+
+            // Create question item
+            final Questionnaire.QuestionnaireItemComponent questionItem =
+                createQuestionItem(hasMemberRel, searchService, terminology, groupProcessedCodes);
+            if (questionItem != null) {
+              questions.add(questionItem);
+              groupProcessedCodes.add(questionCode); // Mark as processed to
+                                                     // avoid duplicates within
+                                                     // this group
+              logger.debug("Successfully created question item for code: {}", questionCode);
+            } else {
+              logger.warn(
+                  "Failed to create question item for code: {} - createQuestionItem returned null",
+                  questionCode);
+            }
+          } else {
+            if (questionCode == null) {
+              logger.warn("Question code is null for hasMemberRel: {}", hasMemberRel);
+            } else if (groupProcessedCodes.contains(questionCode)) {
+              logger.debug("Skipping already processed code: {}", questionCode);
+            }
+          }
+        }
+      }
+
+    } catch (final Exception e) {
+      // Log error but don't fail the entire questionnaire
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.warn("Failed to find questions for group {}: {}", groupCode, e.getMessage());
+    }
+
+    return questions;
+  }
+
+  /**
+   * Creates a question item from a has_member relationship.
+   *
+   * @param hasMemberRel the has_member relationship
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param processedCodes set of already processed codes
+   * @return the questionnaire item component
+   * @throws Exception the exception
+   */
+  private static Questionnaire.QuestionnaireItemComponent createQuestionItem(
+    final ConceptRelationship hasMemberRel, final EntityRepositoryService searchService,
+    final Terminology terminology, final Set<String> processedCodes) throws Exception {
+
+    final Questionnaire.QuestionnaireItemComponent questionItem =
+        new Questionnaire.QuestionnaireItemComponent();
+
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept =
+          TerminologyUtility.getConcept(searchService, terminology.getAbbreviation(),
+              terminology.getPublisher(), terminology.getVersion(), toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
+
+      // Set question properties
+      questionItem.setLinkId(toConcept.getCode());
+      questionItem.setText(displayName);
+      questionItem.setRepeats(false);
+
+      // Add coding
+      final Coding coding = new Coding();
+      coding.setSystem(terminology.getUri());
+      coding.setCode(toConcept.getCode());
+      coding.setDisplay(displayName);
+      questionItem.addCode(coding);
+
+      // Find answer options for this question
+      final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions =
+          findAnswerOptionsForQuestion(toConcept.getCode(), searchService, terminology);
+
+      questionItem.setType(resolveQuestionnaireItemType(memberConcept, answerOptions));
+      for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
+        questionItem.addAnswerOption(option);
+      }
+    }
+
+    return questionItem;
+  }
+
+  /**
+   * Finds answer options for a question via has_answers relationships. Follows LOINC structure:
+   * Question --has_answers--> LL Code <--parent-- LA Codes
+   *
+   * @param questionCode the question LOINC code
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @return list of answer option components
+   * @throws Exception the exception
+   */
+  private static List<Questionnaire.QuestionnaireItemAnswerOptionComponent> findAnswerOptionsForQuestion(
+    final String questionCode, final EntityRepositoryService searchService,
+    final Terminology terminology) throws Exception {
+
+    final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions =
+        new ArrayList<>();
+    final Set<String> uniqueAnswerCodes = new HashSet<>();
+
+    try {
+      // Find has_answers relationships from the question to get LL codes
+      final String hasAnswersQuery = "from.code:" + StringUtility.escapeQuery(questionCode)
+          + " AND additionalType:has_answers";
+      final List<ConceptRelationship> hasAnswersRels =
+          searchService.findAll(hasAnswersQuery, null, ConceptRelationship.class);
+
+      for (final ConceptRelationship hasAnswersRel : hasAnswersRels) {
+        final String llCode = hasAnswersRel.getTo().getCode();
+        if (llCode != null) {
+          // Find parent relationships from LA codes to the LL code
+          final String parentQuery =
+              "to.code:" + StringUtility.escapeQuery(llCode) + " AND type:\"Is a\"";
+          final List<ConceptRelationship> parentRels =
+              searchService.findAll(parentQuery, null, ConceptRelationship.class);
+
+          for (final ConceptRelationship parentRel : parentRels) {
+            final String laCode = parentRel.getFrom().getCode();
+            if (laCode != null && laCode.startsWith("LA") && uniqueAnswerCodes.add(laCode)) {
+              try {
+                // Get the full Concept object to access attributes
+                final Concept laConcept =
+                    TerminologyUtility.getConcept(searchService, terminology.getAbbreviation(),
+                        terminology.getPublisher(), terminology.getVersion(), laCode);
+
+                if (laConcept != null) {
+                  // Create answer option component
+                  final Questionnaire.QuestionnaireItemAnswerOptionComponent option =
+                      new Questionnaire.QuestionnaireItemAnswerOptionComponent();
+
+                  // Set the value coding for the LA code
+                  final Coding valueCoding = new Coding();
+                  valueCoding.setSystem(terminology.getUri());
+                  valueCoding.setCode(laCode);
+                  valueCoding.setDisplay(laConcept.getName());
+                  option.setValue(valueCoding);
+
+                  answerOptions.add(option);
+                }
+              } catch (final Exception e) {
+                // Log error but continue with other options
+                final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+                logger.warn("Failed to get concept for LA code {}: {}", laCode, e.getMessage());
+              }
+            }
+          }
+        }
+      }
+
+    } catch (final Exception e) {
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.warn("Failed to find answer options for question {}: {}", questionCode,
+          e.getMessage());
+    }
+
+    return answerOptions;
+  }
+
+  /**
+   * Determines if a concept is an organizer concept based on its attributes.
+   *
+   * @param concept the concept to check
+   * @return true if it's an organizer, false otherwise
+   */
+  private static boolean isOrganizerConcept(final Concept concept) {
+    // Check for PanelType attribute = "Organizer"
+    if (concept.getAttributes() != null) {
+      final String panelType = concept.getAttributes().get("PanelType");
+      if ("Organizer".equals(panelType)) {
+        return true;
+      }
+    }
+
+    // Fallback: check if name contains "organizer" (case insensitive)
+    final String name = concept.getName();
+    if (name != null && name.toLowerCase().contains("organizer")) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
+   * Creates a direct question item from a has_member relationship.
+   *
+   * @param hasMemberRel the has_member relationship
+   * @param searchService the search service
+   * @param terminology the terminology
+   * @param processedCodes set of already processed codes
+   * @param latestVersion the latest version
+   * @return the questionnaire item component
+   * @throws Exception the exception
+   */
+  private static Questionnaire.QuestionnaireItemComponent createDirectQuestionItem(
+    final ConceptRelationship hasMemberRel, final EntityRepositoryService searchService,
+    final Terminology terminology, final Set<String> processedCodes, final String latestVersion)
+    throws Exception {
+
+    final Questionnaire.QuestionnaireItemComponent questionItem =
+        new Questionnaire.QuestionnaireItemComponent();
+
+    final ConceptRef memberRef = getMemberConceptRef(hasMemberRel);
+    if (memberRef != null) {
+      final ConceptRef toConcept = memberRef;
+      final Concept memberConcept = TerminologyUtility.getConcept(searchService,
+          terminology.getAbbreviation(), terminology.getPublisher(), latestVersion,
+          toConcept.getCode());
+      final String displayName = resolveLoincDisplayName(memberConcept, toConcept);
+
+      // Set question properties
+      questionItem.setLinkId(toConcept.getCode());
+      questionItem.setText(displayName);
+      questionItem.setRepeats(false);
+
+      // Add coding
+      final Coding coding = new Coding();
+      coding.setSystem(terminology.getUri());
+      coding.setCode(toConcept.getCode());
+      coding.setDisplay(displayName);
+      questionItem.addCode(coding);
+
+      // Find answer options for this question
+      final List<Questionnaire.QuestionnaireItemAnswerOptionComponent> answerOptions =
+          findAnswerOptionsForQuestion(toConcept.getCode(), searchService, terminology);
+
+      questionItem.setType(resolveQuestionnaireItemType(memberConcept, answerOptions));
+      for (final Questionnaire.QuestionnaireItemAnswerOptionComponent option : answerOptions) {
+        questionItem.addAnswerOption(option);
+      }
+    }
+
+    return questionItem;
+  }
+
+  /**
+   * Gets the system URI for a terminology based on its abbreviation, publisher, and version. This
+   * method uses TerminologyUtility to get the actual URI from the database.
+   *
+   * @param searchService the search service
+   * @param terminology the terminology abbreviation
+   * @param publisher the publisher
+   * @param version the version
+   * @return the system URI
+   */
+  private static String getSystemUriFromTerminology(final EntityRepositoryService searchService,
+    final String terminology, final String publisher, final String version) {
+
+    try {
+      final Terminology term =
+          TerminologyUtility.getTerminology(searchService, terminology, publisher, version);
+      if (term != null && term.getUri() != null) {
+        return term.getUri();
+      }
+    } catch (final Exception e) {
+      final Logger logger = LoggerFactory.getLogger(FhirUtilityR5.class);
+      logger.warn("Failed to get terminology URI from database for {}: {}", terminology,
+          e.getMessage());
+    }
+
+    return null;
   }
 }

--- a/src/main/java/com/wci/termhub/fhir/rest/r5/HapiR5RestfulServlet.java
+++ b/src/main/java/com/wci/termhub/fhir/rest/r5/HapiR5RestfulServlet.java
@@ -19,6 +19,7 @@ import com.wci.termhub.fhir.r5.ConceptMapProviderR5;
 import com.wci.termhub.fhir.r5.FHIRMetadataProviderR5;
 import com.wci.termhub.fhir.r5.FHIRTerminologyCapabilitiesR5;
 import com.wci.termhub.fhir.r5.SystemTransactionProviderR5;
+import com.wci.termhub.fhir.r5.QuestionnaireProviderR5;
 import com.wci.termhub.fhir.r5.ValueSetProviderR5;
 
 import ca.uhn.fhir.context.FhirContext;
@@ -68,7 +69,8 @@ public class HapiR5RestfulServlet extends RestfulServer {
     }
     setResourceProviders(applicationContext.getBean(CodeSystemProviderR5.class),
         applicationContext.getBean(ValueSetProviderR5.class),
-        applicationContext.getBean(ConceptMapProviderR5.class));
+        applicationContext.getBean(ConceptMapProviderR5.class),
+        applicationContext.getBean(QuestionnaireProviderR5.class));
 
     final FHIRTerminologyCapabilitiesR5 terminologyCapabilitiesR5 =
         applicationContext.getBean(FHIRTerminologyCapabilitiesR5.class);

--- a/src/main/java/com/wci/termhub/fhir/util/LoincConstants.java
+++ b/src/main/java/com/wci/termhub/fhir/util/LoincConstants.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 West Coast Informatics - All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of West Coast Informatics
+ * The intellectual and technical concepts contained herein are proprietary to
+ * West Coast Informatics and may be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.  Dissemination of this information
+ * or reproduction of this material is strictly forbidden.
+ */
+package com.wci.termhub.fhir.util;
+
+/**
+ * Shared LOINC identifiers used across FHIR providers and utilities.
+ */
+public final class LoincConstants {
+
+  /** LOINC canonical URI. */
+  public static final String LOINC_URI = "http://loinc.org";
+
+  /** LOINC system abbreviation. */
+  public static final String LOINC_SYSTEM = "LOINC";
+
+  /** Alternate LOINC system abbreviation (e.g. sandbox). */
+  public static final String LOINC_SYSTEM_ALT = "LNC";
+
+  /** LOINC publisher as stored in loaded terminology data. */
+  public static final String LOINC_PUBLISHER = "Regenstrief Institute, Inc.";
+
+  /** Alternate LOINC publisher string seen in some indexes. */
+  public static final String LOINC_PUBLISHER_ALT = "Regenstrief Institute";
+
+  /** LOINC survey instruments concept code. */
+  public static final String LOINC_SURVEY_INSTRUMENTS_CODE = "LP29696-9";
+
+  /** URL prefix for LOINC value sets (query form). */
+  public static final String LOINC_VS_URL_PREFIX = "http://loinc.org?fhir_vs";
+
+  /** Path prefix for LOINC value set URLs (e.g. http://loinc.org/vs/LG51018-6-2.72). */
+  public static final String LOINC_VS_PATH_PREFIX = "http://loinc.org/vs/";
+
+  /** Path prefix for LOINC value set URLs (HTTPS). */
+  public static final String LOINC_VS_PATH_PREFIX_HTTPS = "https://loinc.org/vs/";
+
+  /** Concept attribute for answer list ID (LOINC). */
+  public static final String ATTR_ANSWER_LIST_ID = "ANSWER_LIST_ID";
+
+  /** LOINC short common name concept attribute. */
+  public static final String ATTR_SHORT_COMMON_NAME = "SHORT_COMMON_NAME";
+
+  /** LOINC short common name term/designation type. */
+  public static final String TERM_TYPE_SHORT_COMMON_NAME = "SHORT_COMMON_NAME";
+
+  /** LOINC short name concept attribute (official LOINC column). */
+  public static final String ATTR_SHORTNAME = "SHORTNAME";
+
+  /** LOINC short name term/designation type. */
+  public static final String TERM_TYPE_SHORTNAME = "SHORTNAME";
+
+  /** Panel membership relationship (full LOINC loads). */
+  public static final String LOINC_REL_PANEL_MEMBER = "member";
+
+  /** Panel membership relationship (sandbox / legacy). */
+  public static final String LOINC_REL_HAS_MEMBER = "has_member";
+
+  private LoincConstants() {
+    // utility class
+  }
+}

--- a/src/main/java/com/wci/termhub/fhir/util/LoincValueSetHelper.java
+++ b/src/main/java/com/wci/termhub/fhir/util/LoincValueSetHelper.java
@@ -9,6 +9,15 @@
  */
 package com.wci.termhub.fhir.util;
 
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_PUBLISHER;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_PUBLISHER_ALT;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_SYSTEM;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_SYSTEM_ALT;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_URI;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_VS_PATH_PREFIX;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_VS_PATH_PREFIX_HTTPS;
+import static com.wci.termhub.fhir.util.LoincConstants.LOINC_VS_URL_PREFIX;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -46,15 +55,6 @@ public class LoincValueSetHelper {
   /** The Constant logger. */
   private static final Logger LOGGER = LoggerFactory.getLogger(LoincValueSetHelper.class);
 
-  /** URL prefix for LOINC value sets (query form). */
-  public static final String LOINC_VS_URL_PREFIX = "http://loinc.org?fhir_vs";
-
-  /** Path prefix for LOINC value set URLs (e.g. http://loinc.org/vs/LG51018-6-2.72). */
-  public static final String LOINC_VS_PATH_PREFIX = "http://loinc.org/vs/";
-
-  /** Path prefix for LOINC value set URLs (HTTPS). */
-  private static final String LOINC_VS_PATH_PREFIX_HTTPS = "https://loinc.org/vs/";
-
   /** LL pattern: LL followed by digits, hyphen, digits (e.g. LL1162-8). */
   private static final Pattern LL_PATTERN = Pattern.compile("^LL\\d+-\\d+$");
 
@@ -63,15 +63,6 @@ public class LoincValueSetHelper {
    * LG51018-6 or LG51018-6-2.78).
    */
   private static final Pattern LG_PATTERN = Pattern.compile("^LG\\d+-\\d+(-[\\d.]+)?$");
-
-  /** LOINC system abbreviation. */
-  public static final String LOINC_SYSTEM = "LOINC";
-
-  /** LOINC publisher. */
-  public static final String LOINC_PUBLISHER = "Regenstrief Institute";
-
-  /** Concept attribute for answer list ID (LOINC). */
-  public static final String ATTR_ANSWER_LIST_ID = "ANSWER_LIST_ID";
 
   /** The enabled. */
   @Value("${fhir.loinc.lllg.valuesets.enabled:false}")
@@ -399,13 +390,60 @@ public class LoincValueSetHelper {
   }
 
   /**
+   * Returns the base LL/LG code without a version suffix (e.g. LG51018-6-2.78 -> LG51018-6).
+   *
+   * @param lllgId the full id
+   * @return base code
+   */
+  public String getBaseLllgCode(final String lllgId) {
+    if (lllgId == null) {
+      return null;
+    }
+    if (getVersionFromLllgId(lllgId) != null) {
+      return lllgId.substring(0, lllgId.lastIndexOf('-'));
+    }
+    return lllgId;
+  }
+
+  /**
+   * Finds the Concept backing an LL/LG value set.
+   *
+   * @param searchService the search service
+   * @param terminology LOINC terminology
+   * @param lllgId the LL or LG id (may include version suffix for LG)
+   * @return the concept or null
+   * @throws Exception the exception
+   */
+  public Concept findLllgConcept(final EntityRepositoryService searchService,
+    final Terminology terminology, final String lllgId) throws Exception {
+    if (lllgId == null || terminology == null) {
+      return null;
+    }
+    final String baseCode = getBaseLllgCode(lllgId);
+    Concept concept = TerminologyUtility.getConcept(searchService, terminology, baseCode);
+    if (concept != null) {
+      return concept;
+    }
+    final String termQuery = TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), "*");
+    final String query = StringUtility.composeQuery("AND", termQuery,
+        StringUtility.escapeKeywordField("code", baseCode));
+    final SearchParameters params = new SearchParameters(query, 1, 0);
+    final ResultList<Concept> result = searchService.find(params, Concept.class);
+    if (!result.getItems().isEmpty()) {
+      return result.getItems().get(0);
+    }
+    return null;
+  }
+
+  /**
    * Builds the canonical URL for an LL/LG value set id.
    *
    * @param id the id (e.g. LL1162-8)
    * @return http://loinc.org/?fhir_vs={id}
    */
   public String toLllgUrl(final String id) {
-    return id == null ? null : "http://loinc.org/?fhir_vs=" + id;
+    return id == null ? null : LOINC_URI + "/?fhir_vs=" + id;
   }
 
   /**
@@ -424,26 +462,26 @@ public class LoincValueSetHelper {
         return term;
       }
       term = TerminologyUtility.getLatestTerminologyVersion(searchService, LOINC_SYSTEM,
-          "Regenstrief Institute, Inc.");
+          LOINC_PUBLISHER_ALT);
       if (term != null) {
         return term;
       }
-      term = TerminologyUtility.getLatestTerminologyVersion(searchService, "LNC", null);
-      if (term != null && term.getUri() != null && term.getUri().contains("loinc.org")) {
+      term = TerminologyUtility.getLatestTerminologyVersion(searchService, LOINC_SYSTEM_ALT, null);
+      if (term != null && term.getUri() != null && term.getUri().contains(LOINC_URI)) {
         return term;
       }
       final SearchParameters params = new SearchParameters(
           StringUtility.escapeKeywordField("abbreviation", LOINC_SYSTEM), 50, 0);
       ResultList<Terminology> list = searchService.find(params, Terminology.class);
       List<Terminology> loincTerms = list.getItems().stream()
-          .filter(t -> t.getUri() != null && t.getUri().contains("loinc.org"))
+          .filter(t -> t.getUri() != null && t.getUri().contains(LOINC_URI))
           .toList();
       if (loincTerms.isEmpty()) {
         final SearchParameters lncParams = new SearchParameters(
-            StringUtility.escapeKeywordField("abbreviation", "LNC"), 50, 0);
+            StringUtility.escapeKeywordField("abbreviation", LOINC_SYSTEM_ALT), 50, 0);
         list = searchService.find(lncParams, Terminology.class);
         loincTerms = list.getItems().stream()
-            .filter(t -> t.getUri() != null && t.getUri().contains("loinc.org"))
+            .filter(t -> t.getUri() != null && t.getUri().contains(LOINC_URI))
             .toList();
       }
       if (loincTerms.isEmpty()) {

--- a/src/main/java/com/wci/termhub/fhir/util/QuestionnaireSearchHelper.java
+++ b/src/main/java/com/wci/termhub/fhir/util/QuestionnaireSearchHelper.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 West Coast Informatics - All Rights Reserved.
+ *
+ * NOTICE:  All information contained herein is, and remains the property of West Coast Informatics
+ * The intellectual and technical concepts contained herein are proprietary to
+ * West Coast Informatics and may be covered by U.S. and Foreign Patents, patents in process,
+ * and are protected by trade secret or copyright law.  Dissemination of this information
+ * or reproduction of this material is strictly forbidden.
+ */
+package com.wci.termhub.fhir.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.wci.termhub.model.Concept;
+import com.wci.termhub.model.ResultList;
+import com.wci.termhub.model.SearchParameters;
+import com.wci.termhub.model.Terminology;
+import com.wci.termhub.service.EntityRepositoryService;
+import com.wci.termhub.util.StringUtility;
+import com.wci.termhub.util.TerminologyUtility;
+
+/**
+ * Finds LOINC panel concepts for FHIR Questionnaire search. Questionnaire is always scoped to the
+ * latest loaded LOINC release (e.g. 2.81); callers must pass the terminology from
+ * {@link LoincValueSetHelper#findLoincTerminology(EntityRepositoryService)}.
+ */
+@Component
+public class QuestionnaireSearchHelper {
+
+  /** The logger. */
+  private static final Logger LOGGER = LoggerFactory.getLogger(QuestionnaireSearchHelper.class);
+
+  /** Lucene clause for LOINC panel concepts. */
+  private static final String PANEL_TYPE_CLAUSE = "attributes.PanelType:Panel";
+
+  /** Batch size for paginated concept queries. */
+  private static final int BATCH_SIZE = 5000;
+
+  /** Cache lock. */
+  private final Object cacheLock = new Object();
+
+  /** Cached terminology key. */
+  private String cachedTerminologyKey;
+
+  /** Cached panel concepts for the latest LOINC version. */
+  private List<Concept> cachedPanelConcepts;
+
+  /**
+   * Returns panel concepts for the given latest LOINC terminology, using an indexed query when
+   * available and an in-memory cache to avoid repeated full scans.
+   *
+   * @param searchService the search service
+   * @param latestLoincTerminology latest LOINC terminology (abbreviation, publisher, version)
+   * @return panel concepts for questionnaire conversion
+   * @throws Exception the exception
+   */
+  public List<Concept> findPanelConcepts(final EntityRepositoryService searchService,
+    final Terminology latestLoincTerminology) throws Exception {
+
+    final String cacheKey = buildCacheKey(latestLoincTerminology);
+    synchronized (cacheLock) {
+      if (cacheKey.equals(cachedTerminologyKey) && cachedPanelConcepts != null) {
+        return cachedPanelConcepts;
+      }
+    }
+
+    List<Concept> panels = queryPanelConcepts(searchService, latestLoincTerminology);
+    if (panels.isEmpty()) {
+      LOGGER.info(
+          "No indexed panel concepts for LOINC {} {} (attributes.PanelType:Panel); scanning release",
+          latestLoincTerminology.getAbbreviation(), latestLoincTerminology.getVersion());
+      panels = scanPanelConcepts(searchService, latestLoincTerminology);
+    } else if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Found {} panel concepts via attributes.PanelType index for LOINC {}",
+          panels.size(), latestLoincTerminology.getVersion());
+    }
+
+    synchronized (cacheLock) {
+      cachedTerminologyKey = cacheKey;
+      cachedPanelConcepts = panels;
+    }
+    return panels;
+  }
+
+  /**
+   * Clears the cached panel list (e.g. after LOINC reload).
+   */
+  public void clearCache() {
+    synchronized (cacheLock) {
+      cachedTerminologyKey = null;
+      cachedPanelConcepts = null;
+    }
+  }
+
+  /**
+   * Checks if a concept has {@code PanelType=Panel}.
+   *
+   * @param concept the concept
+   * @return true when the concept is a LOINC panel
+   */
+  public static boolean isPanelConcept(final Concept concept) {
+    return concept != null && concept.getAttributes() != null
+        && "Panel".equals(concept.getAttributes().get("PanelType"));
+  }
+
+  /**
+   * @param terminology the terminology
+   * @return cache key
+   */
+  private String buildCacheKey(final Terminology terminology) {
+    if (terminology.getId() != null) {
+      return terminology.getId();
+    }
+    return TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), terminology.getVersion());
+  }
+
+  /**
+   * @param searchService the search service
+   * @param terminology latest LOINC terminology
+   * @return panel concepts from indexed query
+   * @throws Exception the exception
+   */
+  private List<Concept> queryPanelConcepts(final EntityRepositoryService searchService,
+    final Terminology terminology) throws Exception {
+
+    final String termQuery = TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), terminology.getVersion());
+    final String query = StringUtility.composeQuery("AND", termQuery, PANEL_TYPE_CLAUSE);
+    return fetchAllConcepts(searchService, query);
+  }
+
+  /**
+   * Fallback when {@code attributes.PanelType} is not yet indexed: scan only the latest LOINC
+   * release and filter in memory.
+   *
+   * @param searchService the search service
+   * @param terminology latest LOINC terminology
+   * @return panel concepts
+   * @throws Exception the exception
+   */
+  private List<Concept> scanPanelConcepts(final EntityRepositoryService searchService,
+    final Terminology terminology) throws Exception {
+
+    final String termQuery = TerminologyUtility.getTerminologyQuery(terminology.getAbbreviation(),
+        terminology.getPublisher(), terminology.getVersion());
+    final List<Concept> panels = new ArrayList<>();
+    int offset = 0;
+    long total = Long.MAX_VALUE;
+    long scanned = 0;
+
+    while (offset < total) {
+      final SearchParameters params = new SearchParameters();
+      params.setQuery(termQuery);
+      params.setLimit(BATCH_SIZE);
+      params.setOffset(offset);
+      params.getSort().add("code");
+      params.setAscending(true);
+
+      final ResultList<Concept> batch = searchService.findAll(params, Concept.class);
+      total = batch.getTotal();
+      if (batch.getItems().isEmpty()) {
+        break;
+      }
+
+      scanned += batch.getItems().size();
+      for (final Concept concept : batch.getItems()) {
+        if (isPanelConcept(concept)) {
+          panels.add(concept);
+        }
+      }
+      offset += BATCH_SIZE;
+    }
+
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Scanned {} concepts in LOINC {}, found {} panels", scanned,
+          terminology.getVersion(), panels.size());
+    }
+    return panels;
+  }
+
+  /**
+   * @param searchService the search service
+   * @param query the lucene query
+   * @return all matching concepts
+   * @throws Exception the exception
+   */
+  private List<Concept> fetchAllConcepts(final EntityRepositoryService searchService,
+    final String query) throws Exception {
+
+    final List<Concept> concepts = new ArrayList<>();
+    int offset = 0;
+    long total = Long.MAX_VALUE;
+
+    while (offset < total) {
+      final SearchParameters params = new SearchParameters();
+      params.setQuery(query);
+      params.setLimit(BATCH_SIZE);
+      params.setOffset(offset);
+      params.getSort().add("code");
+      params.setAscending(true);
+
+      final ResultList<Concept> batch = searchService.findAll(params, Concept.class);
+      total = batch.getTotal();
+      if (batch.getItems().isEmpty()) {
+        break;
+      }
+      concepts.addAll(batch.getItems());
+      offset += BATCH_SIZE;
+    }
+    return concepts;
+  }
+}

--- a/src/main/java/com/wci/termhub/lucene/LuceneDataAccess.java
+++ b/src/main/java/com/wci/termhub/lucene/LuceneDataAccess.java
@@ -31,7 +31,9 @@ import org.apache.lucene.analysis.pattern.PatternReplaceFilter;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.analysis.standard.StandardTokenizer;
 import org.apache.lucene.document.Document;
+import org.apache.lucene.document.SortedSetDocValuesField;
 import org.apache.lucene.document.StoredField;
+import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
@@ -48,6 +50,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.FSDirectory;
+import org.apache.lucene.util.BytesRef;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -275,6 +278,20 @@ public class LuceneDataAccess {
 
               }
               refClass = refClass.getSuperclass();
+            }
+
+          } else if (fieldType == FieldType.Object && fieldValue instanceof Map
+              && "attributes".equals(field.getName())) {
+
+            for (final Map.Entry<?, ?> entry : ((Map<?, ?>) fieldValue).entrySet()) {
+              if (entry.getKey() == null || entry.getValue() == null) {
+                continue;
+              }
+              final String indexName = field.getName() + "." + entry.getKey();
+              final String indexValue = String.valueOf(entry.getValue());
+              document.add(new StringField(indexName, indexValue,
+                  org.apache.lucene.document.Field.Store.NO));
+              document.add(new SortedSetDocValuesField(indexName, new BytesRef(indexValue)));
             }
           }
 

--- a/src/main/java/com/wci/termhub/lucene/LuceneQueryBuilder.java
+++ b/src/main/java/com/wci/termhub/lucene/LuceneQueryBuilder.java
@@ -15,6 +15,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -68,6 +70,10 @@ public final class LuceneQueryBuilder {
   private static final Map<Class<?>, Map<String, AnalyzerType>> FIELD_ANALYZER_TYPES_CACHE =
       new HashMap<>();
 
+  /** Matches {@code attributes.SomeKey:} clauses in query strings. */
+  private static final Pattern ATTRIBUTE_FIELD_PATTERN =
+      Pattern.compile("attributes\\.([A-Za-z0-9_\\-]+)\\s*:");
+
   /**
    * Parses the query for a specific model class.
    *
@@ -86,6 +92,7 @@ public final class LuceneQueryBuilder {
     for (final Map.Entry<String, AnalyzerType> entry : analyzerTypes.entrySet()) {
       fieldAnalyzers.put(entry.getKey(), entry.getValue().newInstance());
     }
+    registerAttributeFieldAnalyzers(queryText, fieldAnalyzers);
     final String[] searchableFields = getSearchableFields(modelClass);
 
     // Create PerFieldAnalyzerWrapper with field-specific analyzers
@@ -100,6 +107,26 @@ public final class LuceneQueryBuilder {
       queryParser.setAllowLeadingWildcard(true);
 
       return queryParser.parse(queryText);
+    }
+  }
+
+  /**
+   * Registers keyword analyzers for {@code attributes.*} fields referenced in the query so values
+   * match case-sensitive {@link org.apache.lucene.document.StringField} indexing.
+   *
+   * @param queryText the query text
+   * @param fieldAnalyzers the per-field analyzer map to augment
+   */
+  private static void registerAttributeFieldAnalyzers(final String queryText,
+    final Map<String, Analyzer> fieldAnalyzers) {
+
+    if (queryText == null) {
+      return;
+    }
+    final Matcher matcher = ATTRIBUTE_FIELD_PATTERN.matcher(queryText);
+    while (matcher.find()) {
+      final String fieldName = "attributes." + matcher.group(1);
+      fieldAnalyzers.put(fieldName, AnalyzerType.KEYWORD.newInstance());
     }
   }
 

--- a/src/main/java/com/wci/termhub/util/ValueSetLoaderUtil.java
+++ b/src/main/java/com/wci/termhub/util/ValueSetLoaderUtil.java
@@ -264,6 +264,9 @@ public final class ValueSetLoaderUtil {
         subset.getAttributes().put(Subset.Attributes.fhirExperimental.name(),
             Boolean.toString(valueSet.getExperimental()));
       }
+      if (valueSet.hasCopyright() && !StringUtility.isEmpty(valueSet.getCopyright())) {
+        subset.getAttributes().put("copyright", valueSet.getCopyright());
+      }
 
       subset.setCategory("ValueSet");
       service.add(Subset.class, subset);
@@ -420,7 +423,7 @@ public final class ValueSetLoaderUtil {
       // Set listener to 100%
       listener.updateProgress(new ProgressEvent(100));
 
-      return FhirUtilityR4.toR4ValueSet(subset, null, false);
+      return FhirUtilityR4.toR4ValueSet(subset, null, false, service);
 
     } catch (final Exception e) {
       LOGGER.error("Error indexing value set", e);
@@ -544,6 +547,9 @@ public final class ValueSetLoaderUtil {
         }
         subset.getAttributes().put(Subset.Attributes.fhirExperimental.name(),
             Boolean.toString(valueSet.getExperimental()));
+      }
+      if (valueSet.hasCopyright() && !StringUtility.isEmpty(valueSet.getCopyright())) {
+        subset.getAttributes().put("copyright", valueSet.getCopyright());
       }
 
       subset.setCategory("ValueSet");
@@ -698,7 +704,7 @@ public final class ValueSetLoaderUtil {
       // Set listener to 100%
       listener.updateProgress(new ProgressEvent(100));
 
-      return FhirUtilityR5.toR5ValueSet(subset, null, false);
+      return FhirUtilityR5.toR5ValueSet(subset, null, false, service);
 
     } catch (final Exception e) {
       LOGGER.error("Error indexing value set", e);

--- a/src/test/java/com/wci/termhub/fhir/r4/test/FhirUtilityR4MetaUnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r4/test/FhirUtilityR4MetaUnitTest.java
@@ -27,6 +27,7 @@ import org.hl7.fhir.r4.model.ValueSet;
 import org.junit.jupiter.api.Test;
 
 import com.wci.termhub.fhir.rest.r4.FhirUtilityR4;
+import com.wci.termhub.model.Concept;
 import com.wci.termhub.model.Mapset;
 import com.wci.termhub.model.Terminology;
 import com.wci.termhub.util.DateUtility;
@@ -208,6 +209,8 @@ public class FhirUtilityR4MetaUnitTest {
    */
   @Test
   public void testQuestionnaireMeta() throws Exception {
+    final String copyright =
+        "This material contains content from LOINC (http://loinc.org). LOINC is copyright Regenstrief Institute, Inc.";
     final Terminology terminology = new Terminology();
     terminology.setId("test-cs");
     terminology.setReleaseDate("2022-04-11");
@@ -216,12 +219,40 @@ public class FhirUtilityR4MetaUnitTest {
     terminology.setName("Test CodeSystem");
     terminology.setAbbreviation("TCS");
     terminology.setPublisher("Test");
-    terminology.setAttributes(new HashMap<>());
+    final Map<String, String> attrs = new HashMap<>();
+    attrs.put("copyright", copyright);
+    terminology.setAttributes(attrs);
     terminology.setCreated(Date.from(LocalDate.now(ZoneOffset.UTC).atStartOfDay(ZoneOffset.UTC).toInstant()));
 
     final Questionnaire q = FhirUtilityR4.toR4Questionnaire(terminology, true);
     assertNotNull(q.getMeta());
     assertEquals("1", q.getMeta().getVersionId());
     assertNotNull(q.getMeta().getLastUpdated());
+    assertNotNull(q.getDate());
+    assertEquals(q.getDate(), q.getMeta().getLastUpdated());
+    assertEquals(copyright, q.getCopyright());
+  }
+
+  /**
+   * Test Questionnaire name/title from LOINC SHORTNAME (short common name).
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testQuestionnaireNameTitleFromShortName() throws Exception {
+    final Concept concept = new Concept();
+    concept.setCode("100105-6");
+    concept.setName("Filaria IgG and IgM panel - Serum");
+    concept.setTerminology("LOINC");
+    concept.setPublisher("Regenstrief Institute, Inc.");
+    concept.setVersion("2.81");
+    final Map<String, String> attrs = new HashMap<>();
+    attrs.put("SHORTNAME", "Filaria Ab.IgG + IgM Pnl Ser");
+    concept.setAttributes(attrs);
+
+    final Questionnaire q = FhirUtilityR4.toR4Questionnaire(concept, null, null);
+    assertEquals("Filaria_Ab_IgG_IgM_Pnl_Ser", q.getName());
+    assertEquals("Filaria Ab.IgG + IgM Pnl Ser", q.getTitle());
+    assertEquals("Filaria Ab.IgG + IgM Pnl Ser", q.getCodeFirstRep().getDisplay());
   }
 }

--- a/src/test/java/com/wci/termhub/fhir/r4/test/LoincValueSetR4UnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r4/test/LoincValueSetR4UnitTest.java
@@ -33,6 +33,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.TestPropertySource;
 
 import com.wci.termhub.fhir.r4.ValueSetProviderR4;
+import com.wci.termhub.fhir.rest.r4.FhirUtilityR4;
 import com.wci.termhub.fhir.util.LoincValueSetHelper;
 
 import ca.uhn.fhir.rest.param.StringParam;
@@ -47,6 +48,12 @@ import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
  */
 @TestPropertySource(properties = "fhir.loinc.lllg.valuesets.enabled=true")
 public class LoincValueSetR4UnitTest extends AbstractFhirR4ServerTest {
+
+  /** The Constant LG_VS_URL. */
+  private static final String LG_VS_URL = "http://loinc.org?fhir_vs=LG50982-4";
+
+  /** The Constant LG_VS_ID. */
+  private static final String LG_VS_ID = "LG50982-4";
 
   /** The Constant LL_VS_URL. */
   private static final String LL_VS_URL = "http://loinc.org?fhir_vs=LL1772-4";
@@ -70,6 +77,26 @@ public class LoincValueSetR4UnitTest extends AbstractFhirR4ServerTest {
 
   /** The details. */
   private ServletRequestDetails details;
+
+  /** UUID pattern for ValueSet ids. */
+  private static final String UUID_PATTERN =
+      "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+
+  /**
+   * Asserts a LOINC LL/LG ValueSet uses a Concept UUID as id and retains the code in meta.
+   *
+   * @param vs the value set
+   * @param lllgCode the expected LL/LG code
+   */
+  private static void assertLllgValueSetHasUuidId(final ValueSet vs, final String lllgCode) {
+    assertNotNull(vs.getId(), "ValueSet id should not be null");
+    assertFalse(lllgCode.equals(vs.getId()),
+        "ValueSet id should be Concept UUID, not LL/LG code " + lllgCode);
+    assertTrue(vs.getId().matches(UUID_PATTERN), "ValueSet id should be a UUID");
+    assertTrue(vs.getMeta().getTag().stream().anyMatch(
+        t -> FhirUtilityR4.META_LOINC_LLLG_ID.equals(t.getSystem()) && lllgCode.equals(t.getCode())),
+        "ValueSet should have loincLllgId meta tag for " + lllgCode);
+  }
 
   /**
    * Sets the up.
@@ -118,10 +145,31 @@ public class LoincValueSetR4UnitTest extends AbstractFhirR4ServerTest {
       assertTrue(
           bundle.getEntry().stream()
               .anyMatch(e -> e.getResource() instanceof ValueSet
-                  && LL_VS_URL.equals(((ValueSet) e.getResource()).getUrl())
-                  && LL_VS_ID.equals(e.getResource().getId())),
+                  && LL_VS_URL.equals(((ValueSet) e.getResource()).getUrl())),
           "Bundle should contain LL value set for " + LL_VS_URL);
     }
+
+  /**
+   * Test find LG value set by url uses Concept UUID as id.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testFindLgValueSetByUrlHasUuidId() throws Exception {
+    final UriParam url = new UriParam(LG_VS_URL);
+    final Bundle bundle = provider.findValueSets(request, details, null, null, null, null, null,
+        null, null, null, url, null, null, null);
+    assertNotNull(bundle);
+    final ValueSet found = bundle.getEntry().stream()
+        .map(e -> e.getResource())
+        .filter(ValueSet.class::isInstance)
+        .map(ValueSet.class::cast)
+        .filter(v -> LG_VS_URL.equals(v.getUrl()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull(found, "Bundle should contain LG value set for " + LG_VS_URL);
+    assertLllgValueSetHasUuidId(found, LG_VS_ID);
+  }
 
   /**
    * Test get lllg value set by id.
@@ -161,7 +209,9 @@ public class LoincValueSetR4UnitTest extends AbstractFhirR4ServerTest {
     assertNotNull(vs);
     assertNotNull(vs.getExpansion(), "Expansion should be present");
     assertTrue(vs.getExpansion().getTotal() >= 0, "Total should be non-negative");
-    assertTrue(LL_VS_ID.equals(vs.getId()) || vs.getId() != null);
+    if (vs.getId() != null) {
+      assertFalse(LL_VS_ID.equals(vs.getId()), "Expanded ValueSet id should not be the LL/LG code");
+    }
     assertTrue(
         vs.getExpansion().getParameter().stream().anyMatch(p -> "offset".equals(p.getName())),
         "Expansion should have offset parameter like fhir.loinc.org");
@@ -180,13 +230,42 @@ public class LoincValueSetR4UnitTest extends AbstractFhirR4ServerTest {
   public void testValueSetReadLllgById() throws Exception {
     final ValueSet vs = provider.getValueSet(request, details, new IdType(LL_VS_ID));
     assertNotNull(vs);
-    assertEquals(LL_VS_ID, vs.getIdPart());
     assertEquals(LL_VS_URL, vs.getUrl());
     assertTrue(
         vs.getCompose() != null && vs.getCompose().getInclude() != null
             && !vs.getCompose().getInclude().isEmpty()
             || vs.getExpansion() != null && vs.getExpansion().getContains() != null,
         "LL value set should have compose or expansion with members");
+  }
+
+  /**
+   * Test ValueSet read by LG code returns Concept UUID as id.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testValueSetReadLgById() throws Exception {
+    final ValueSet vs = provider.getValueSet(request, details, new IdType(LG_VS_ID));
+    assertNotNull(vs);
+    assertLllgValueSetHasUuidId(vs, LG_VS_ID);
+    assertEquals(LG_VS_URL, vs.getUrl());
+  }
+
+  /**
+   * Test ValueSet read by Concept UUID for LOINC LG value set.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testValueSetReadLgByUuid() throws Exception {
+    final ValueSet byCode = provider.getValueSet(request, details, new IdType(LG_VS_ID));
+    assertNotNull(byCode.getId());
+    final ValueSet byUuid =
+        provider.getValueSet(request, details, new IdType(byCode.getId()));
+    assertNotNull(byUuid);
+    assertEquals(byCode.getId(), byUuid.getId());
+    assertEquals(LG_VS_URL, byUuid.getUrl());
+    assertLllgValueSetHasUuidId(byUuid, LG_VS_ID);
   }
 
   /**

--- a/src/test/java/com/wci/termhub/fhir/r5/test/FhirUtilityR5MetaUnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r5/test/FhirUtilityR5MetaUnitTest.java
@@ -22,10 +22,12 @@ import java.util.Map;
 
 import org.hl7.fhir.r5.model.CodeSystem;
 import org.hl7.fhir.r5.model.ConceptMap;
+import org.hl7.fhir.r5.model.Questionnaire;
 import org.hl7.fhir.r5.model.ValueSet;
 import org.junit.jupiter.api.Test;
 
 import com.wci.termhub.fhir.rest.r5.FhirUtilityR5;
+import com.wci.termhub.model.Concept;
 import com.wci.termhub.model.Mapset;
 import com.wci.termhub.model.Terminology;
 import com.wci.termhub.util.DateUtility;
@@ -197,5 +199,59 @@ public class FhirUtilityR5MetaUnitTest {
     assertNotNull(cm.getMeta());
     assertEquals("1", cm.getMeta().getVersionId());
     assertNotNull(cm.getMeta().getLastUpdated());
+  }
+
+  /**
+   * Test Questionnaire meta has versionId, lastUpdated, and copyright.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testQuestionnaireMeta() throws Exception {
+    final String copyright =
+        "This material contains content from LOINC (http://loinc.org). LOINC is copyright Regenstrief Institute, Inc.";
+    final Terminology terminology = new Terminology();
+    terminology.setId("test-cs");
+    terminology.setReleaseDate("2022-04-11");
+    terminology.setUri("http://example.org/cs");
+    terminology.setVersion("1");
+    terminology.setName("Test CodeSystem");
+    terminology.setAbbreviation("TCS");
+    terminology.setPublisher("Test");
+    final Map<String, String> attrs = new HashMap<>();
+    attrs.put("copyright", copyright);
+    terminology.setAttributes(attrs);
+    terminology.setCreated(Date.from(LocalDate.now(ZoneOffset.UTC).atStartOfDay(ZoneOffset.UTC).toInstant()));
+
+    final Questionnaire q = FhirUtilityR5.toR5Questionnaire(terminology, true);
+    assertNotNull(q.getMeta());
+    assertEquals("1", q.getMeta().getVersionId());
+    assertNotNull(q.getMeta().getLastUpdated());
+    assertNotNull(q.getDate());
+    assertEquals(q.getDate(), q.getMeta().getLastUpdated());
+    assertEquals(copyright, q.getCopyright());
+  }
+
+  /**
+   * Test Questionnaire name/title from LOINC SHORTNAME (short common name).
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testQuestionnaireNameTitleFromShortName() throws Exception {
+    final Concept concept = new Concept();
+    concept.setCode("100105-6");
+    concept.setName("Filaria IgG and IgM panel - Serum");
+    concept.setTerminology("LOINC");
+    concept.setPublisher("Regenstrief Institute, Inc.");
+    concept.setVersion("2.81");
+    final Map<String, String> attrs = new HashMap<>();
+    attrs.put("SHORTNAME", "Filaria Ab.IgG + IgM Pnl Ser");
+    concept.setAttributes(attrs);
+
+    final Questionnaire q = FhirUtilityR5.toR5Questionnaire(concept, null, null);
+    assertEquals("Filaria_Ab_IgG_IgM_Pnl_Ser", q.getName());
+    assertEquals("Filaria Ab.IgG + IgM Pnl Ser", q.getTitle());
+    assertEquals("Filaria Ab.IgG + IgM Pnl Ser", q.getCodeFirstRep().getDisplay());
   }
 }

--- a/src/test/java/com/wci/termhub/fhir/r5/test/LoincValueSetR5UnitTest.java
+++ b/src/test/java/com/wci/termhub/fhir/r5/test/LoincValueSetR5UnitTest.java
@@ -10,6 +10,7 @@
 package com.wci.termhub.fhir.r5.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -30,6 +31,7 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.context.TestPropertySource;
 
 import com.wci.termhub.fhir.r5.ValueSetProviderR5;
+import com.wci.termhub.fhir.rest.r5.FhirUtilityR5;
 import com.wci.termhub.fhir.util.LoincValueSetHelper;
 
 import ca.uhn.fhir.rest.param.StringParam;
@@ -44,6 +46,12 @@ import ca.uhn.fhir.rest.server.servlet.ServletRequestDetails;
  */
 @TestPropertySource(properties = "fhir.loinc.lllg.valuesets.enabled=true")
 public class LoincValueSetR5UnitTest extends AbstractFhirR5ServerTest {
+
+  /** The Constant LG_VS_URL. */
+  private static final String LG_VS_URL = "http://loinc.org?fhir_vs=LG50982-4";
+
+  /** The Constant LG_VS_ID. */
+  private static final String LG_VS_ID = "LG50982-4";
 
   /** The Constant LL_VS_URL. */
   private static final String LL_VS_URL = "http://loinc.org?fhir_vs=LL1772-4";
@@ -67,6 +75,26 @@ public class LoincValueSetR5UnitTest extends AbstractFhirR5ServerTest {
 
   /** The details. */
   private ServletRequestDetails details;
+
+  /** UUID pattern for ValueSet ids. */
+  private static final String UUID_PATTERN =
+      "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+
+  /**
+   * Asserts a LOINC LL/LG ValueSet uses a Concept UUID as id and retains the code in meta.
+   *
+   * @param vs the value set
+   * @param lllgCode the expected LL/LG code
+   */
+  private static void assertLllgValueSetHasUuidId(final ValueSet vs, final String lllgCode) {
+    assertNotNull(vs.getId(), "ValueSet id should not be null");
+    assertFalse(lllgCode.equals(vs.getId()),
+        "ValueSet id should be Concept UUID, not LL/LG code " + lllgCode);
+    assertTrue(vs.getId().matches(UUID_PATTERN), "ValueSet id should be a UUID");
+    assertTrue(vs.getMeta().getTag().stream().anyMatch(
+        t -> FhirUtilityR5.META_LOINC_LLLG_ID.equals(t.getSystem()) && lllgCode.equals(t.getCode())),
+        "ValueSet should have loincLllgId meta tag for " + lllgCode);
+  }
 
   /**
    * Sets the up.
@@ -115,9 +143,30 @@ public class LoincValueSetR5UnitTest extends AbstractFhirR5ServerTest {
     assertTrue(
         bundle.getEntry().stream()
             .anyMatch(e -> e.getResource() instanceof ValueSet
-                && LL_VS_URL.equals(((ValueSet) e.getResource()).getUrl())
-                && LL_VS_ID.equals(e.getResource().getId())),
+                && LL_VS_URL.equals(((ValueSet) e.getResource()).getUrl())),
         "Bundle should contain LL value set for " + LL_VS_URL);
+  }
+
+  /**
+   * Test find LG value set by url uses Concept UUID as id.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testFindLgValueSetByUrlHasUuidId() throws Exception {
+    final UriParam url = new UriParam(LG_VS_URL);
+    final Bundle bundle = provider.findValueSets(request, details, null, null, null, null, null,
+        null, null, null, url, null, null, null);
+    assertNotNull(bundle);
+    final ValueSet found = bundle.getEntry().stream()
+        .map(e -> e.getResource())
+        .filter(ValueSet.class::isInstance)
+        .map(ValueSet.class::cast)
+        .filter(v -> LG_VS_URL.equals(v.getUrl()))
+        .findFirst()
+        .orElse(null);
+    assertNotNull(found, "Bundle should contain LG value set for " + LG_VS_URL);
+    assertLllgValueSetHasUuidId(found, LG_VS_ID);
   }
 
   /**
@@ -158,7 +207,9 @@ public class LoincValueSetR5UnitTest extends AbstractFhirR5ServerTest {
     assertNotNull(vs);
     assertNotNull(vs.getExpansion(), "Expansion should be present");
     assertTrue(vs.getExpansion().getTotal() >= 0, "Total should be non-negative");
-    assertTrue(LL_VS_ID.equals(vs.getId()) || vs.getId() != null);
+    if (vs.getId() != null) {
+      assertFalse(LL_VS_ID.equals(vs.getId()), "Expanded ValueSet id should not be the LL/LG code");
+    }
     assertTrue(
         vs.getExpansion().getParameter().stream().anyMatch(p -> "offset".equals(p.getName())),
         "Expansion should have offset parameter like fhir.loinc.org");
@@ -177,13 +228,42 @@ public class LoincValueSetR5UnitTest extends AbstractFhirR5ServerTest {
   public void testValueSetReadLllgById() throws Exception {
     final ValueSet vs = provider.getValueSet(request, details, new IdType(LL_VS_ID));
     assertNotNull(vs);
-    assertEquals(LL_VS_ID, vs.getIdPart());
     assertEquals(LL_VS_URL, vs.getUrl());
     assertTrue(
         vs.getCompose() != null && vs.getCompose().getInclude() != null
             && !vs.getCompose().getInclude().isEmpty()
             || vs.getExpansion() != null && vs.getExpansion().getContains() != null,
         "LL value set should have compose or expansion with members");
+  }
+
+  /**
+   * Test ValueSet read by LG code returns Concept UUID as id.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testValueSetReadLgById() throws Exception {
+    final ValueSet vs = provider.getValueSet(request, details, new IdType(LG_VS_ID));
+    assertNotNull(vs);
+    assertLllgValueSetHasUuidId(vs, LG_VS_ID);
+    assertEquals(LG_VS_URL, vs.getUrl());
+  }
+
+  /**
+   * Test ValueSet read by Concept UUID for LOINC LG value set.
+   *
+   * @throws Exception the exception
+   */
+  @Test
+  public void testValueSetReadLgByUuid() throws Exception {
+    final ValueSet byCode = provider.getValueSet(request, details, new IdType(LG_VS_ID));
+    assertNotNull(byCode.getId());
+    final ValueSet byUuid =
+        provider.getValueSet(request, details, new IdType(byCode.getId()));
+    assertNotNull(byUuid);
+    assertEquals(byCode.getId(), byUuid.getId());
+    assertEquals(LG_VS_URL, byUuid.getUrl());
+    assertLllgValueSetHasUuidId(byUuid, LG_VS_ID);
   }
 
 


### PR DESCRIPTION
Add terminology copyright if valueset does not have a copyright.
Fix exception with questionnaire for /fhir/r4/ & r5/Questionnaire/{id}
Return all questionnaires with /fhir/r4 & r5/Questionnaire - Originally was only returning 29